### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/iterm2
+* @tinted-theming/iterm2

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16-project/base16-schemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -15,17 +15,17 @@ jobs:
       - name: Fetch the schemes repository
         uses: actions/checkout@v3
         with:
-          repository: base16-project/base16-schemes
+          repository: tinted-theming/base16-schemes
           path: schemes
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-iterm2/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-iterm2
@@ -52,7 +52,7 @@ the information on the GitHub page.
   colorschemes, make changes to the template instead.
 - Please abide by what's requested in the [PR template][4].
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 Copyright (c) 2017-2018 Martin Lindhe
 Copyright (C) 2012-2017 Chris Kempson
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ hand if you'd like to keep your 16 ANSI colors intact, go ahead and use
 the 256 color variations but please note you'll need to modify some of
 the 256 colorspace with the [Base16 Shell][2] script.
 
-[1]: https://github.com/base16-project/home
-[2]: https://github.com/base16-project/base16-shell
+[1]: https://github.com/tinted-theming/home
+[2]: https://github.com/tinted-theming/base16-shell
 [3]: screenshots/base16-iterm2.png
 [4]: screenshots/base16-iterm2-256.png

--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Base16 {{scheme-name}}-256
-    Template: Chris Kempson, Scheme: {{scheme-author}}
+    Scheme author: {{scheme-author}}
+    Template author: Tinted Theming (https://github.com/tinted-theming)
     semanticClass: theme.base16.{{scheme-slug}}
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Base16 {{scheme-name}}
-    Template: Chris Kempson, Scheme: {{scheme-author}}
+    Scheme author: {{scheme-author}}
+    Template author: Tinted Theming (https://github.com/tinted-theming)
     semanticClass: theme.base16.{{scheme-slug}}
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.