### PR TITLE
Add oascripts to change theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ systems than Base16 so it has been renamed.
   from this repo
 - Load the theme by clicking on `Color Presets` and selecting it
 
+### Tinty
+
+If you use [Tinty] to set your themes, append the following to your
+tinty/config.toml file and your theme will update when applying a theme:
+
+```toml
+[[items]]
+path = "https://github.com/tinted-theming/tinted-iterm2"
+name = "tinted-iterm2"
+hook = "sh %f"
+themes-dir = "scripts"
+supported-systems = ["base16", "base24"]
+```
+
+Note: The above uses `sh` to run the hook script so make sure you have
+that shell installed. Most Unix-based systems have it in `$PATH` by
+default.
+
 ## Bright Ansi colors
 
 Base16 will use the same colors for normal and bright variants. Base24

--- a/scripts/base16-3024.sh
+++ b/scripts/base16-3024.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {2313, 771, 0}
+        set foreground color to {42405, 41634, 41634}
+
+        -- Set ANSI Colors
+        set ANSI black color to {2313, 771, 0}
+        set ANSI red color to {56283, 11565, 8224}
+        set ANSI green color to {257, 41634, 21074}
+        set ANSI yellow color to {65021, 60909, 514}
+        set ANSI blue color to {257, 41120, 58596}
+        set ANSI magenta color to {41377, 27242, 38036}
+        set ANSI cyan color to {46517, 58596, 62708}
+        set ANSI white color to {54998, 54741, 54484}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19018, 17733, 17219}
+        set ANSI bright red color to {56283, 11565, 8224}
+        set ANSI bright green color to {257, 41634, 21074}
+        set ANSI bright yellow color to {65021, 60909, 514}
+        set ANSI bright blue color to {257, 41120, 58596}
+        set ANSI bright magenta color to {41377, 27242, 38036}
+        set ANSI bright cyan color to {46517, 58596, 62708}
+        set ANSI bright white color to {63479, 63479, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-apathy.sh
+++ b/scripts/base16-apathy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {771, 6682, 5654}
+        set foreground color to {33153, 46517, 44204}
+
+        -- Set ANSI Colors
+        set ANSI black color to {771, 6682, 5654}
+        set ANSI red color to {15934, 38550, 34952}
+        set ANSI green color to {34952, 15934, 38550}
+        set ANSI yellow color to {15934, 19532, 38550}
+        set ANSI blue color to {38550, 34952, 15934}
+        set ANSI magenta color to {19532, 38550, 15934}
+        set ANSI cyan color to {38550, 15934, 19532}
+        set ANSI white color to {42919, 52942, 51400}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {6168, 20046, 17733}
+        set ANSI bright red color to {15934, 38550, 34952}
+        set ANSI bright green color to {34952, 15934, 38550}
+        set ANSI bright yellow color to {15934, 19532, 38550}
+        set ANSI bright blue color to {38550, 34952, 15934}
+        set ANSI bright magenta color to {19532, 38550, 15934}
+        set ANSI bright cyan color to {38550, 15934, 19532}
+        set ANSI bright white color to {53970, 59367, 58596}
+    end tell
+end tell
+EOF

--- a/scripts/base16-apprentice.sh
+++ b/scripts/base16-apprentice.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 9766, 9766}
+        set foreground color to {24415, 24415, 34695}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 9766, 9766}
+        set ANSI red color to {17476, 17476, 17476}
+        set ANSI green color to {65535, 65535, 44975}
+        set ANSI yellow color to {34695, 44975, 34695}
+        set ANSI blue color to {34695, 34695, 44975}
+        set ANSI magenta color to {24415, 44975, 44975}
+        set ANSI cyan color to {34695, 44975, 55255}
+        set ANSI white color to {24415, 34695, 34695}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24415, 34695, 24415}
+        set ANSI bright red color to {17476, 17476, 17476}
+        set ANSI bright green color to {65535, 65535, 44975}
+        set ANSI bright yellow color to {34695, 44975, 34695}
+        set ANSI bright blue color to {34695, 34695, 44975}
+        set ANSI bright magenta color to {24415, 44975, 44975}
+        set ANSI bright cyan color to {34695, 44975, 55255}
+        set ANSI bright white color to {27756, 27756, 27756}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ashes.sh
+++ b/scripts/base16-ashes.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 8224, 8995}
+        set foreground color to {51143, 52428, 53713}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 8224, 8995}
+        set ANSI red color to {51143, 44718, 38293}
+        set ANSI green color to {38293, 51143, 44718}
+        set ANSI yellow color to {44718, 51143, 38293}
+        set ANSI blue color to {44718, 38293, 51143}
+        set ANSI magenta color to {51143, 38293, 44718}
+        set ANSI cyan color to {38293, 44718, 51143}
+        set ANSI white color to {57311, 58082, 58853}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22102, 24158, 25957}
+        set ANSI bright red color to {51143, 44718, 38293}
+        set ANSI bright green color to {38293, 51143, 44718}
+        set ANSI bright yellow color to {44718, 51143, 38293}
+        set ANSI bright blue color to {44718, 38293, 51143}
+        set ANSI bright magenta color to {51143, 38293, 44718}
+        set ANSI bright cyan color to {38293, 44718, 51143}
+        set ANSI bright white color to {62451, 62708, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-cave-light.sh
+++ b/scripts/base16-atelier-cave-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61423, 60652, 62708}
+        set foreground color to {22616, 21074, 24672}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61423, 60652, 62708}
+        set ANSI red color to {48830, 17990, 30840}
+        set ANSI green color to {10794, 37522, 37522}
+        set ANSI yellow color to {41120, 28270, 15163}
+        set ANSI blue color to {22359, 28013, 56283}
+        set ANSI magenta color to {38293, 23130, 59367}
+        set ANSI cyan color to {14649, 35723, 50886}
+        set ANSI white color to {9766, 8995, 10794}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {35723, 34695, 37522}
+        set ANSI bright red color to {48830, 17990, 30840}
+        set ANSI bright green color to {10794, 37522, 37522}
+        set ANSI bright yellow color to {41120, 28270, 15163}
+        set ANSI bright blue color to {22359, 28013, 56283}
+        set ANSI bright magenta color to {38293, 23130, 59367}
+        set ANSI bright cyan color to {14649, 35723, 50886}
+        set ANSI bright white color to {6425, 5911, 7196}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-cave.sh
+++ b/scripts/base16-atelier-cave.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6425, 5911, 7196}
+        set foreground color to {35723, 34695, 37522}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6425, 5911, 7196}
+        set ANSI red color to {48830, 17990, 30840}
+        set ANSI green color to {10794, 37522, 37522}
+        set ANSI yellow color to {41120, 28270, 15163}
+        set ANSI blue color to {22359, 28013, 56283}
+        set ANSI magenta color to {38293, 23130, 59367}
+        set ANSI cyan color to {14649, 35723, 50886}
+        set ANSI white color to {58082, 57311, 59367}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 21074, 24672}
+        set ANSI bright red color to {48830, 17990, 30840}
+        set ANSI bright green color to {10794, 37522, 37522}
+        set ANSI bright yellow color to {41120, 28270, 15163}
+        set ANSI bright blue color to {22359, 28013, 56283}
+        set ANSI bright magenta color to {38293, 23130, 59367}
+        set ANSI bright cyan color to {14649, 35723, 50886}
+        set ANSI bright white color to {61423, 60652, 62708}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-dune-light.sh
+++ b/scripts/base16-atelier-dune-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65278, 64507, 60652}
+        set foreground color to {28270, 27499, 24158}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65278, 64507, 60652}
+        set ANSI red color to {55255, 14135, 14135}
+        set ANSI green color to {24672, 44204, 14649}
+        set ANSI yellow color to {44718, 38293, 4883}
+        set ANSI blue color to {26214, 33924, 57825}
+        set ANSI magenta color to {47288, 21588, 54484}
+        set ANSI cyan color to {7967, 44461, 33667}
+        set ANSI white color to {10537, 10280, 9252}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {42662, 41634, 35980}
+        set ANSI bright red color to {55255, 14135, 14135}
+        set ANSI bright green color to {24672, 44204, 14649}
+        set ANSI bright yellow color to {44718, 38293, 4883}
+        set ANSI bright blue color to {26214, 33924, 57825}
+        set ANSI bright magenta color to {47288, 21588, 54484}
+        set ANSI bright cyan color to {7967, 44461, 33667}
+        set ANSI bright white color to {8224, 8224, 7453}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-dune.sh
+++ b/scripts/base16-atelier-dune.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 8224, 7453}
+        set foreground color to {42662, 41634, 35980}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 8224, 7453}
+        set ANSI red color to {55255, 14135, 14135}
+        set ANSI green color to {24672, 44204, 14649}
+        set ANSI yellow color to {44718, 38293, 4883}
+        set ANSI blue color to {26214, 33924, 57825}
+        set ANSI magenta color to {47288, 21588, 54484}
+        set ANSI cyan color to {7967, 44461, 33667}
+        set ANSI white color to {59624, 58596, 53199}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {28270, 27499, 24158}
+        set ANSI bright red color to {55255, 14135, 14135}
+        set ANSI bright green color to {24672, 44204, 14649}
+        set ANSI bright yellow color to {44718, 38293, 4883}
+        set ANSI bright blue color to {26214, 33924, 57825}
+        set ANSI bright magenta color to {47288, 21588, 54484}
+        set ANSI bright cyan color to {7967, 44461, 33667}
+        set ANSI bright white color to {65278, 64507, 60652}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-estuary-light.sh
+++ b/scripts/base16-atelier-estuary-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62708, 62451, 60652}
+        set foreground color to {24415, 24158, 20046}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62708, 62451, 60652}
+        set ANSI red color to {47802, 25186, 13878}
+        set ANSI green color to {32125, 38807, 9766}
+        set ANSI yellow color to {42405, 39064, 3341}
+        set ANSI blue color to {13878, 41377, 26214}
+        set ANSI magenta color to {24415, 37265, 33410}
+        set ANSI cyan color to {23387, 40349, 18504}
+        set ANSI white color to {12336, 12079, 10023}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {37522, 37265, 33153}
+        set ANSI bright red color to {47802, 25186, 13878}
+        set ANSI bright green color to {32125, 38807, 9766}
+        set ANSI bright yellow color to {42405, 39064, 3341}
+        set ANSI bright blue color to {13878, 41377, 26214}
+        set ANSI bright magenta color to {24415, 37265, 33410}
+        set ANSI bright cyan color to {23387, 40349, 18504}
+        set ANSI bright white color to {8738, 8738, 6939}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-estuary.sh
+++ b/scripts/base16-atelier-estuary.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 8738, 6939}
+        set foreground color to {37522, 37265, 33153}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 8738, 6939}
+        set ANSI red color to {47802, 25186, 13878}
+        set ANSI green color to {32125, 38807, 9766}
+        set ANSI yellow color to {42405, 39064, 3341}
+        set ANSI blue color to {13878, 41377, 26214}
+        set ANSI magenta color to {24415, 37265, 33410}
+        set ANSI cyan color to {23387, 40349, 18504}
+        set ANSI white color to {59367, 59110, 57311}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24415, 24158, 20046}
+        set ANSI bright red color to {47802, 25186, 13878}
+        set ANSI bright green color to {32125, 38807, 9766}
+        set ANSI bright yellow color to {42405, 39064, 3341}
+        set ANSI bright blue color to {13878, 41377, 26214}
+        set ANSI bright magenta color to {24415, 37265, 33410}
+        set ANSI bright cyan color to {23387, 40349, 18504}
+        set ANSI bright white color to {62708, 62451, 60652}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-forest-light.sh
+++ b/scripts/base16-atelier-forest-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61937, 61423, 61166}
+        set foreground color to {26728, 24929, 24158}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61937, 61423, 61166}
+        set ANSI red color to {62194, 11308, 16448}
+        set ANSI green color to {31611, 38807, 9766}
+        set ANSI yellow color to {50115, 33924, 6168}
+        set ANSI blue color to {16448, 32382, 59367}
+        set ANSI magenta color to {26214, 26214, 60138}
+        set ANSI cyan color to {15677, 38807, 47288}
+        set ANSI white color to {11308, 9252, 8481}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {43176, 41377, 40863}
+        set ANSI bright red color to {62194, 11308, 16448}
+        set ANSI bright green color to {31611, 38807, 9766}
+        set ANSI bright yellow color to {50115, 33924, 6168}
+        set ANSI bright blue color to {16448, 32382, 59367}
+        set ANSI bright magenta color to {26214, 26214, 60138}
+        set ANSI bright cyan color to {15677, 38807, 47288}
+        set ANSI bright white color to {6939, 6425, 6168}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-forest.sh
+++ b/scripts/base16-atelier-forest.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6939, 6425, 6168}
+        set foreground color to {43176, 41377, 40863}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6939, 6425, 6168}
+        set ANSI red color to {62194, 11308, 16448}
+        set ANSI green color to {31611, 38807, 9766}
+        set ANSI yellow color to {50115, 33924, 6168}
+        set ANSI blue color to {16448, 32382, 59367}
+        set ANSI magenta color to {26214, 26214, 60138}
+        set ANSI cyan color to {15677, 38807, 47288}
+        set ANSI white color to {59110, 58082, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {26728, 24929, 24158}
+        set ANSI bright red color to {62194, 11308, 16448}
+        set ANSI bright green color to {31611, 38807, 9766}
+        set ANSI bright yellow color to {50115, 33924, 6168}
+        set ANSI bright blue color to {16448, 32382, 59367}
+        set ANSI bright magenta color to {26214, 26214, 60138}
+        set ANSI bright cyan color to {15677, 38807, 47288}
+        set ANSI bright white color to {61937, 61423, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-heath-light.sh
+++ b/scripts/base16-atelier-heath-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63479, 62451, 63479}
+        set foreground color to {26985, 23901, 26985}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63479, 62451, 63479}
+        set ANSI red color to {51914, 16448, 11051}
+        set ANSI green color to {37265, 35723, 15163}
+        set ANSI yellow color to {48059, 35466, 13621}
+        set ANSI blue color to {20817, 27242, 60652}
+        set ANSI magenta color to {31611, 22873, 49344}
+        set ANSI cyan color to {5397, 37779, 37779}
+        set ANSI white color to {10537, 8995, 10537}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {43947, 39835, 43947}
+        set ANSI bright red color to {51914, 16448, 11051}
+        set ANSI bright green color to {37265, 35723, 15163}
+        set ANSI bright yellow color to {48059, 35466, 13621}
+        set ANSI bright blue color to {20817, 27242, 60652}
+        set ANSI bright magenta color to {31611, 22873, 49344}
+        set ANSI bright cyan color to {5397, 37779, 37779}
+        set ANSI bright white color to {6939, 6168, 6939}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-heath.sh
+++ b/scripts/base16-atelier-heath.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6939, 6168, 6939}
+        set foreground color to {43947, 39835, 43947}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6939, 6168, 6939}
+        set ANSI red color to {51914, 16448, 11051}
+        set ANSI green color to {37265, 35723, 15163}
+        set ANSI yellow color to {48059, 35466, 13621}
+        set ANSI blue color to {20817, 27242, 60652}
+        set ANSI magenta color to {31611, 22873, 49344}
+        set ANSI cyan color to {5397, 37779, 37779}
+        set ANSI white color to {55512, 51914, 55512}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {26985, 23901, 26985}
+        set ANSI bright red color to {51914, 16448, 11051}
+        set ANSI bright green color to {37265, 35723, 15163}
+        set ANSI bright yellow color to {48059, 35466, 13621}
+        set ANSI bright blue color to {20817, 27242, 60652}
+        set ANSI bright magenta color to {31611, 22873, 49344}
+        set ANSI bright cyan color to {5397, 37779, 37779}
+        set ANSI bright white color to {63479, 62451, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-lakeside-light.sh
+++ b/scripts/base16-atelier-lakeside-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {60395, 63736, 65535}
+        set foreground color to {20817, 28013, 31611}
+
+        -- Set ANSI Colors
+        set ANSI black color to {60395, 63736, 65535}
+        set ANSI red color to {53970, 11565, 29298}
+        set ANSI green color to {22102, 35980, 15163}
+        set ANSI yellow color to {35466, 35466, 3855}
+        set ANSI blue color to {9509, 32639, 44461}
+        set ANSI magenta color to {27499, 27499, 47288}
+        set ANSI cyan color to {11565, 36751, 28527}
+        set ANSI white color to {7967, 10537, 11822}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {32382, 41634, 46260}
+        set ANSI bright red color to {53970, 11565, 29298}
+        set ANSI bright green color to {22102, 35980, 15163}
+        set ANSI bright yellow color to {35466, 35466, 3855}
+        set ANSI bright blue color to {9509, 32639, 44461}
+        set ANSI bright magenta color to {27499, 27499, 47288}
+        set ANSI bright cyan color to {11565, 36751, 28527}
+        set ANSI bright white color to {5654, 6939, 7453}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-lakeside.sh
+++ b/scripts/base16-atelier-lakeside.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5654, 6939, 7453}
+        set foreground color to {32382, 41634, 46260}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5654, 6939, 7453}
+        set ANSI red color to {53970, 11565, 29298}
+        set ANSI green color to {22102, 35980, 15163}
+        set ANSI yellow color to {35466, 35466, 3855}
+        set ANSI blue color to {9509, 32639, 44461}
+        set ANSI magenta color to {27499, 27499, 47288}
+        set ANSI cyan color to {11565, 36751, 28527}
+        set ANSI white color to {49601, 58596, 63222}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 28013, 31611}
+        set ANSI bright red color to {53970, 11565, 29298}
+        set ANSI bright green color to {22102, 35980, 15163}
+        set ANSI bright yellow color to {35466, 35466, 3855}
+        set ANSI bright blue color to {9509, 32639, 44461}
+        set ANSI bright magenta color to {27499, 27499, 47288}
+        set ANSI bright cyan color to {11565, 36751, 28527}
+        set ANSI bright white color to {60395, 63736, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-plateau-light.sh
+++ b/scripts/base16-atelier-plateau-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62708, 60652, 60652}
+        set foreground color to {22616, 20560, 20560}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62708, 60652, 60652}
+        set ANSI red color to {51914, 18761, 18761}
+        set ANSI green color to {19275, 35723, 35723}
+        set ANSI yellow color to {41120, 28270, 15163}
+        set ANSI blue color to {29298, 29298, 51914}
+        set ANSI magenta color to {33924, 25700, 50372}
+        set ANSI cyan color to {21588, 34181, 46774}
+        set ANSI white color to {10537, 9252, 9252}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {35466, 34181, 34181}
+        set ANSI bright red color to {51914, 18761, 18761}
+        set ANSI bright green color to {19275, 35723, 35723}
+        set ANSI bright yellow color to {41120, 28270, 15163}
+        set ANSI bright blue color to {29298, 29298, 51914}
+        set ANSI bright magenta color to {33924, 25700, 50372}
+        set ANSI bright cyan color to {21588, 34181, 46774}
+        set ANSI bright white color to {6939, 6168, 6168}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-plateau.sh
+++ b/scripts/base16-atelier-plateau.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6939, 6168, 6168}
+        set foreground color to {35466, 34181, 34181}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6939, 6168, 6168}
+        set ANSI red color to {51914, 18761, 18761}
+        set ANSI green color to {19275, 35723, 35723}
+        set ANSI yellow color to {41120, 28270, 15163}
+        set ANSI blue color to {29298, 29298, 51914}
+        set ANSI magenta color to {33924, 25700, 50372}
+        set ANSI cyan color to {21588, 34181, 46774}
+        set ANSI white color to {59367, 57311, 57311}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 20560, 20560}
+        set ANSI bright red color to {51914, 18761, 18761}
+        set ANSI bright green color to {19275, 35723, 35723}
+        set ANSI bright yellow color to {41120, 28270, 15163}
+        set ANSI bright blue color to {29298, 29298, 51914}
+        set ANSI bright magenta color to {33924, 25700, 50372}
+        set ANSI bright cyan color to {21588, 34181, 46774}
+        set ANSI bright white color to {62708, 60652, 60652}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-savanna-light.sh
+++ b/scripts/base16-atelier-savanna-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {60652, 62708, 61166}
+        set foreground color to {21074, 24672, 22359}
+
+        -- Set ANSI Colors
+        set ANSI black color to {60652, 62708, 61166}
+        set ANSI red color to {45489, 24929, 14649}
+        set ANSI green color to {18504, 39321, 25443}
+        set ANSI yellow color to {41120, 32382, 15163}
+        set ANSI blue color to {18247, 35980, 37008}
+        set ANSI magenta color to {21845, 34181, 39835}
+        set ANSI cyan color to {7196, 39578, 41120}
+        set ANSI white color to {8995, 10794, 9509}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {34695, 37522, 35466}
+        set ANSI bright red color to {45489, 24929, 14649}
+        set ANSI bright green color to {18504, 39321, 25443}
+        set ANSI bright yellow color to {41120, 32382, 15163}
+        set ANSI bright blue color to {18247, 35980, 37008}
+        set ANSI bright magenta color to {21845, 34181, 39835}
+        set ANSI bright cyan color to {7196, 39578, 41120}
+        set ANSI bright white color to {5911, 7196, 6425}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-savanna.sh
+++ b/scripts/base16-atelier-savanna.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 7196, 6425}
+        set foreground color to {34695, 37522, 35466}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 7196, 6425}
+        set ANSI red color to {45489, 24929, 14649}
+        set ANSI green color to {18504, 39321, 25443}
+        set ANSI yellow color to {41120, 32382, 15163}
+        set ANSI blue color to {18247, 35980, 37008}
+        set ANSI magenta color to {21845, 34181, 39835}
+        set ANSI cyan color to {7196, 39578, 41120}
+        set ANSI white color to {57311, 59367, 58082}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21074, 24672, 22359}
+        set ANSI bright red color to {45489, 24929, 14649}
+        set ANSI bright green color to {18504, 39321, 25443}
+        set ANSI bright yellow color to {41120, 32382, 15163}
+        set ANSI bright blue color to {18247, 35980, 37008}
+        set ANSI bright magenta color to {21845, 34181, 39835}
+        set ANSI bright cyan color to {7196, 39578, 41120}
+        set ANSI bright white color to {60652, 62708, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-seaside-light.sh
+++ b/scripts/base16-atelier-seaside-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62708, 64507, 62708}
+        set foreground color to {24158, 28270, 24158}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62708, 64507, 62708}
+        set ANSI red color to {59110, 6425, 15420}
+        set ANSI green color to {10537, 41891, 10537}
+        set ANSI yellow color to {39064, 39064, 6939}
+        set ANSI blue color to {15677, 25186, 62965}
+        set ANSI magenta color to {44461, 11051, 61166}
+        set ANSI cyan color to {6425, 39321, 46003}
+        set ANSI white color to {9252, 10537, 9252}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {35980, 42662, 35980}
+        set ANSI bright red color to {59110, 6425, 15420}
+        set ANSI bright green color to {10537, 41891, 10537}
+        set ANSI bright yellow color to {39064, 39064, 6939}
+        set ANSI bright blue color to {15677, 25186, 62965}
+        set ANSI bright magenta color to {44461, 11051, 61166}
+        set ANSI bright cyan color to {6425, 39321, 46003}
+        set ANSI bright white color to {4883, 5397, 4883}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-seaside.sh
+++ b/scripts/base16-atelier-seaside.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4883, 5397, 4883}
+        set foreground color to {35980, 42662, 35980}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4883, 5397, 4883}
+        set ANSI red color to {59110, 6425, 15420}
+        set ANSI green color to {10537, 41891, 10537}
+        set ANSI yellow color to {39064, 39064, 6939}
+        set ANSI blue color to {15677, 25186, 62965}
+        set ANSI magenta color to {44461, 11051, 61166}
+        set ANSI cyan color to {6425, 39321, 46003}
+        set ANSI white color to {53199, 59624, 53199}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24158, 28270, 24158}
+        set ANSI bright red color to {59110, 6425, 15420}
+        set ANSI bright green color to {10537, 41891, 10537}
+        set ANSI bright yellow color to {39064, 39064, 6939}
+        set ANSI bright blue color to {15677, 25186, 62965}
+        set ANSI bright magenta color to {44461, 11051, 61166}
+        set ANSI bright cyan color to {6425, 39321, 46003}
+        set ANSI bright white color to {62708, 64507, 62708}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-sulphurpool-light.sh
+++ b/scripts/base16-atelier-sulphurpool-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62965, 63479, 65535}
+        set foreground color to {24158, 26214, 34695}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62965, 63479, 65535}
+        set ANSI red color to {51657, 18761, 8738}
+        set ANSI green color to {44204, 38807, 14649}
+        set ANSI yellow color to {49344, 35723, 12336}
+        set ANSI blue color to {15677, 36751, 53713}
+        set ANSI magenta color to {26214, 31097, 52428}
+        set ANSI cyan color to {8738, 41634, 51657}
+        set ANSI white color to {10537, 12850, 22102}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {38807, 40349, 46260}
+        set ANSI bright red color to {51657, 18761, 8738}
+        set ANSI bright green color to {44204, 38807, 14649}
+        set ANSI bright yellow color to {49344, 35723, 12336}
+        set ANSI bright blue color to {15677, 36751, 53713}
+        set ANSI bright magenta color to {26214, 31097, 52428}
+        set ANSI bright cyan color to {8738, 41634, 51657}
+        set ANSI bright white color to {8224, 10023, 17990}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atelier-sulphurpool.sh
+++ b/scripts/base16-atelier-sulphurpool.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 10023, 17990}
+        set foreground color to {38807, 40349, 46260}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 10023, 17990}
+        set ANSI red color to {51657, 18761, 8738}
+        set ANSI green color to {44204, 38807, 14649}
+        set ANSI yellow color to {49344, 35723, 12336}
+        set ANSI blue color to {15677, 36751, 53713}
+        set ANSI magenta color to {26214, 31097, 52428}
+        set ANSI cyan color to {8738, 41634, 51657}
+        set ANSI white color to {57311, 58082, 61937}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24158, 26214, 34695}
+        set ANSI bright red color to {51657, 18761, 8738}
+        set ANSI bright green color to {44204, 38807, 14649}
+        set ANSI bright yellow color to {49344, 35723, 12336}
+        set ANSI bright blue color to {15677, 36751, 53713}
+        set ANSI bright magenta color to {26214, 31097, 52428}
+        set ANSI bright cyan color to {8738, 41634, 51657}
+        set ANSI bright white color to {62965, 63479, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-atlas.sh
+++ b/scripts/base16-atlas.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 9766, 13621}
+        set foreground color to {41377, 41377, 39578}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 9766, 13621}
+        set ANSI red color to {65535, 23130, 26471}
+        set ANSI green color to {32639, 49344, 28270}
+        set ANSI yellow color to {65535, 52428, 6939}
+        set ANSI blue color to {5140, 29812, 32382}
+        set ANSI magenta color to {39578, 28784, 42148}
+        set ANSI cyan color to {23901, 55255, 47545}
+        set ANSI white color to {59110, 59110, 56540}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 32639, 36237}
+        set ANSI bright red color to {65535, 23130, 26471}
+        set ANSI bright green color to {32639, 49344, 28270}
+        set ANSI bright yellow color to {65535, 52428, 6939}
+        set ANSI bright blue color to {5140, 29812, 32382}
+        set ANSI bright magenta color to {39578, 28784, 42148}
+        set ANSI bright cyan color to {23901, 55255, 47545}
+        set ANSI bright white color to {64250, 64250, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ayu-dark.sh
+++ b/scripts/base16-ayu-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3855, 5140, 6425}
+        set foreground color to {59110, 57825, 53199}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3855, 5140, 6425}
+        set ANSI red color to {61680, 29041, 30840}
+        set ANSI green color to {47288, 52428, 21074}
+        set ANSI yellow color to {65535, 46260, 21588}
+        set ANSI blue color to {22873, 49858, 65535}
+        set ANSI magenta color to {53970, 42662, 65535}
+        set ANSI cyan color to {38293, 59110, 52171}
+        set ANSI white color to {59110, 57825, 53199}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10023, 11565, 14392}
+        set ANSI bright red color to {61680, 29041, 30840}
+        set ANSI bright green color to {47288, 52428, 21074}
+        set ANSI bright yellow color to {65535, 46260, 21588}
+        set ANSI bright blue color to {22873, 49858, 65535}
+        set ANSI bright magenta color to {53970, 42662, 65535}
+        set ANSI bright cyan color to {38293, 59110, 52171}
+        set ANSI bright white color to {62451, 62708, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ayu-light.sh
+++ b/scripts/base16-ayu-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 64250, 64250}
+        set foreground color to {23644, 26471, 29555}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 64250, 64250}
+        set ANSI red color to {61680, 29041, 30840}
+        set ANSI green color to {34438, 46003, 0}
+        set ANSI yellow color to {62194, 44718, 18761}
+        set ANSI blue color to {13878, 41891, 55769}
+        set ANSI magenta color to {41891, 31354, 52428}
+        set ANSI cyan color to {19532, 49087, 39321}
+        set ANSI white color to {9252, 10537, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {63736, 63993, 64250}
+        set ANSI bright red color to {61680, 29041, 30840}
+        set ANSI bright green color to {34438, 46003, 0}
+        set ANSI bright yellow color to {62194, 44718, 18761}
+        set ANSI bright blue color to {13878, 41891, 55769}
+        set ANSI bright magenta color to {41891, 31354, 52428}
+        set ANSI bright cyan color to {19532, 49087, 39321}
+        set ANSI bright white color to {6682, 7967, 10537}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ayu-mirage.sh
+++ b/scripts/base16-ayu-mirage.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 6939, 9252}
+        set foreground color to {52428, 51914, 49858}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 6939, 9252}
+        set ANSI red color to {62194, 34695, 31097}
+        set ANSI green color to {54741, 65535, 32896}
+        set ANSI yellow color to {65535, 53713, 29555}
+        set ANSI blue color to {23644, 53199, 59110}
+        set ANSI magenta color to {54484, 49087, 65535}
+        set ANSI cyan color to {38293, 59110, 52171}
+        set ANSI white color to {55769, 55255, 52942}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {9252, 10537, 13878}
+        set ANSI bright red color to {62194, 34695, 31097}
+        set ANSI bright green color to {54741, 65535, 32896}
+        set ANSI bright yellow color to {65535, 53713, 29555}
+        set ANSI bright blue color to {23644, 53199, 59110}
+        set ANSI bright magenta color to {54484, 49087, 65535}
+        set ANSI bright cyan color to {38293, 59110, 52171}
+        set ANSI bright white color to {62451, 62708, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-aztec.sh
+++ b/scripts/base16-aztec.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 5654, 0}
+        set foreground color to {65535, 56026, 20817}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 5654, 0}
+        set ANSI red color to {61166, 11822, 0}
+        set ANSI green color to {25443, 55769, 12850}
+        set ANSI yellow color to {61166, 48059, 0}
+        set ANSI blue color to {23387, 19018, 40863}
+        set ANSI magenta color to {34952, 15934, 40863}
+        set ANSI cyan color to {15677, 38036, 42405}
+        set ANSI white color to {65535, 57825, 30840}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {9252, 9766, 1028}
+        set ANSI bright red color to {61166, 11822, 0}
+        set ANSI bright green color to {25443, 55769, 12850}
+        set ANSI bright yellow color to {61166, 48059, 0}
+        set ANSI bright blue color to {23387, 19018, 40863}
+        set ANSI bright magenta color to {34952, 15934, 40863}
+        set ANSI bright cyan color to {15677, 38036, 42405}
+        set ANSI bright white color to {65535, 60395, 41120}
+    end tell
+end tell
+EOF

--- a/scripts/base16-bespin.sh
+++ b/scripts/base16-bespin.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 8481, 7196}
+        set foreground color to {35466, 35209, 34438}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 8481, 7196}
+        set ANSI red color to {53199, 27242, 19532}
+        set ANSI green color to {21588, 48830, 3341}
+        set ANSI yellow color to {63993, 61166, 39064}
+        set ANSI blue color to {24158, 42662, 60138}
+        set ANSI magenta color to {39835, 34181, 40349}
+        set ANSI cyan color to {44975, 50372, 56283}
+        set ANSI white color to {40349, 39835, 38807}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24158, 23901, 23644}
+        set ANSI bright red color to {53199, 27242, 19532}
+        set ANSI bright green color to {21588, 48830, 3341}
+        set ANSI bright yellow color to {63993, 61166, 39064}
+        set ANSI bright blue color to {24158, 42662, 60138}
+        set ANSI bright magenta color to {39835, 34181, 40349}
+        set ANSI bright cyan color to {44975, 50372, 56283}
+        set ANSI bright white color to {47802, 44718, 40606}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-bathory.sh
+++ b/scripts/base16-black-metal-bathory.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {64507, 52171, 38807}
+        set ANSI yellow color to {59367, 35466, 21331}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {64507, 52171, 38807}
+        set ANSI bright yellow color to {59367, 35466, 21331}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-burzum.sh
+++ b/scripts/base16-black-metal-burzum.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {56797, 61166, 52428}
+        set ANSI yellow color to {39321, 48059, 43690}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {56797, 61166, 52428}
+        set ANSI bright yellow color to {39321, 48059, 43690}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-dark-funeral.sh
+++ b/scripts/base16-black-metal-dark-funeral.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {53456, 57311, 61166}
+        set ANSI yellow color to {24415, 33153, 42405}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {53456, 57311, 61166}
+        set ANSI bright yellow color to {24415, 33153, 42405}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-gorgoroth.sh
+++ b/scripts/base16-black-metal-gorgoroth.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {39835, 36237, 32639}
+        set ANSI yellow color to {35980, 32639, 28784}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {39835, 36237, 32639}
+        set ANSI bright yellow color to {35980, 32639, 28784}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-immortal.sh
+++ b/scripts/base16-black-metal-immortal.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {30583, 39321, 48059}
+        set ANSI yellow color to {21845, 26214, 30583}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {30583, 39321, 48059}
+        set ANSI bright yellow color to {21845, 26214, 30583}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-khold.sh
+++ b/scripts/base16-black-metal-khold.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {60652, 61166, 58339}
+        set ANSI yellow color to {38807, 19275, 17990}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {60652, 61166, 58339}
+        set ANSI bright yellow color to {38807, 19275, 17990}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-marduk.sh
+++ b/scripts/base16-black-metal-marduk.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {42405, 43690, 42919}
+        set ANSI yellow color to {25186, 27499, 26471}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {42405, 43690, 42919}
+        set ANSI bright yellow color to {25186, 27499, 26471}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-mayhem.sh
+++ b/scripts/base16-black-metal-mayhem.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {62451, 60652, 54484}
+        set ANSI yellow color to {61166, 52428, 27756}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {62451, 60652, 54484}
+        set ANSI bright yellow color to {61166, 52428, 27756}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-nile.sh
+++ b/scripts/base16-black-metal-nile.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {43690, 39321, 34952}
+        set ANSI yellow color to {30583, 30583, 21845}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {43690, 39321, 34952}
+        set ANSI bright yellow color to {30583, 30583, 21845}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal-venom.sh
+++ b/scripts/base16-black-metal-venom.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {63736, 63479, 62194}
+        set ANSI yellow color to {31097, 9252, 7967}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {63736, 63479, 62194}
+        set ANSI bright yellow color to {31097, 9252, 7967}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-black-metal.sh
+++ b/scripts/base16-black-metal.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49601, 49601, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {24415, 34695, 34695}
+        set ANSI green color to {56797, 39321, 39321}
+        set ANSI yellow color to {41120, 26214, 26214}
+        set ANSI blue color to {34952, 34952, 34952}
+        set ANSI magenta color to {39321, 39321, 39321}
+        set ANSI cyan color to {43690, 43690, 43690}
+        set ANSI white color to {39321, 39321, 39321}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {24415, 34695, 34695}
+        set ANSI bright green color to {56797, 39321, 39321}
+        set ANSI bright yellow color to {41120, 26214, 26214}
+        set ANSI bright blue color to {34952, 34952, 34952}
+        set ANSI bright magenta color to {39321, 39321, 39321}
+        set ANSI bright cyan color to {43690, 43690, 43690}
+        set ANSI bright white color to {49601, 49601, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-blueforest.sh
+++ b/scripts/base16-blueforest.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5140, 7967, 11822}
+        set foreground color to {65535, 52428, 13107}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5140, 7967, 11822}
+        set ANSI red color to {65535, 64250, 45489}
+        set ANSI green color to {32896, 65535, 32896}
+        set ANSI yellow color to {37265, 52428, 65535}
+        set ANSI blue color to {41634, 53199, 62965}
+        set ANSI magenta color to {0, 39321, 65535}
+        set ANSI cyan color to {32896, 65535, 32896}
+        set ANSI white color to {37265, 52428, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10023, 15934, 23644}
+        set ANSI bright red color to {65535, 64250, 45489}
+        set ANSI bright green color to {32896, 65535, 32896}
+        set ANSI bright yellow color to {37265, 52428, 65535}
+        set ANSI bright blue color to {41634, 53199, 62965}
+        set ANSI bright magenta color to {0, 39321, 65535}
+        set ANSI bright cyan color to {32896, 65535, 32896}
+        set ANSI bright white color to {14135, 22359, 32896}
+    end tell
+end tell
+EOF

--- a/scripts/base16-blueish.sh
+++ b/scripts/base16-blueish.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 9252, 12336}
+        set foreground color to {51400, 57825, 63736}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 9252, 12336}
+        set ANSI red color to {19532, 58853, 34695}
+        set ANSI green color to {50115, 59624, 36237}
+        set ANSI yellow color to {33410, 43690, 65535}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {65535, 33924, 56797}
+        set ANSI cyan color to {24415, 53713, 65535}
+        set ANSI white color to {56797, 60138, 63222}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17990, 10537, 2570}
+        set ANSI bright red color to {19532, 58853, 34695}
+        set ANSI bright green color to {50115, 59624, 36237}
+        set ANSI bright yellow color to {33410, 43690, 65535}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {65535, 33924, 56797}
+        set ANSI bright cyan color to {24415, 53713, 65535}
+        set ANSI bright white color to {36751, 39064, 41120}
+    end tell
+end tell
+EOF

--- a/scripts/base16-brewer.sh
+++ b/scripts/base16-brewer.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3084, 3341, 3598}
+        set foreground color to {47031, 47288, 47545}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3084, 3341, 3598}
+        set ANSI red color to {58339, 6682, 7196}
+        set ANSI green color to {12593, 41891, 21588}
+        set ANSI yellow color to {56540, 41120, 24672}
+        set ANSI blue color to {12593, 33410, 48573}
+        set ANSI magenta color to {30069, 27499, 45489}
+        set ANSI cyan color to {32896, 45489, 54227}
+        set ANSI white color to {56026, 56283, 56540}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 21074, 21331}
+        set ANSI bright red color to {58339, 6682, 7196}
+        set ANSI bright green color to {12593, 41891, 21588}
+        set ANSI bright yellow color to {56540, 41120, 24672}
+        set ANSI bright blue color to {12593, 33410, 48573}
+        set ANSI bright magenta color to {30069, 27499, 45489}
+        set ANSI bright cyan color to {32896, 45489, 54227}
+        set ANSI bright white color to {64764, 65021, 65278}
+    end tell
+end tell
+EOF

--- a/scripts/base16-bright.sh
+++ b/scripts/base16-bright.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {57568, 57568, 57568}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {64507, 257, 8224}
+        set ANSI green color to {41377, 50886, 22873}
+        set ANSI yellow color to {65021, 41891, 12593}
+        set ANSI blue color to {28527, 46003, 53970}
+        set ANSI magenta color to {54227, 33153, 50115}
+        set ANSI cyan color to {30326, 51143, 47031}
+        set ANSI white color to {62965, 62965, 62965}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 20560, 20560}
+        set ANSI bright red color to {64507, 257, 8224}
+        set ANSI bright green color to {41377, 50886, 22873}
+        set ANSI bright yellow color to {65021, 41891, 12593}
+        set ANSI bright blue color to {28527, 46003, 53970}
+        set ANSI bright magenta color to {54227, 33153, 50115}
+        set ANSI bright cyan color to {30326, 51143, 47031}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-brogrammer.sh
+++ b/scripts/base16-brogrammer.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7967, 7967, 7967}
+        set foreground color to {20046, 23130, 47031}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7967, 7967, 7967}
+        set ANSI red color to {54998, 56283, 58853}
+        set ANSI green color to {62451, 48573, 2313}
+        set ANSI yellow color to {7453, 54227, 24929}
+        set ANSI blue color to {21331, 20560, 47545}
+        set ANSI magenta color to {3855, 32125, 56283}
+        set ANSI cyan color to {4112, 33153, 54998}
+        set ANSI white color to {4112, 33153, 54998}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11565, 50629, 24158}
+        set ANSI bright red color to {54998, 56283, 58853}
+        set ANSI bright green color to {62451, 48573, 2313}
+        set ANSI bright yellow color to {7453, 54227, 24929}
+        set ANSI bright blue color to {21331, 20560, 47545}
+        set ANSI bright magenta color to {3855, 32125, 56283}
+        set ANSI bright cyan color to {4112, 33153, 54998}
+        set ANSI bright white color to {54998, 56283, 58853}
+    end tell
+end tell
+EOF

--- a/scripts/base16-brushtrees-dark.sh
+++ b/scripts/base16-brushtrees-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {18504, 22616, 26471}
+        set foreground color to {45232, 50629, 51400}
+
+        -- Set ANSI Colors
+        set ANSI black color to {18504, 22616, 26471}
+        set ANSI red color to {46003, 34438, 34438}
+        set ANSI green color to {34695, 46003, 34438}
+        set ANSI yellow color to {43690, 46003, 34438}
+        set ANSI blue color to {34438, 35980, 46003}
+        set ANSI magenta color to {46003, 34438, 45746}
+        set ANSI cyan color to {34438, 46003, 46003}
+        set ANSI white color to {51657, 56283, 56540}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {28013, 33410, 36494}
+        set ANSI bright red color to {46003, 34438, 34438}
+        set ANSI bright green color to {34695, 46003, 34438}
+        set ANSI bright yellow color to {43690, 46003, 34438}
+        set ANSI bright blue color to {34438, 35980, 46003}
+        set ANSI bright magenta color to {46003, 34438, 45746}
+        set ANSI bright cyan color to {34438, 46003, 46003}
+        set ANSI bright white color to {58339, 61423, 61423}
+    end tell
+end tell
+EOF

--- a/scripts/base16-brushtrees.sh
+++ b/scripts/base16-brushtrees.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {58339, 61423, 61423}
+        set foreground color to {28013, 33410, 36494}
+
+        -- Set ANSI Colors
+        set ANSI black color to {58339, 61423, 61423}
+        set ANSI red color to {46003, 34438, 34438}
+        set ANSI green color to {34695, 46003, 34438}
+        set ANSI yellow color to {43690, 46003, 34438}
+        set ANSI blue color to {34438, 35980, 46003}
+        set ANSI magenta color to {46003, 34438, 45746}
+        set ANSI cyan color to {34438, 46003, 46003}
+        set ANSI white color to {23130, 28013, 31354}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {45232, 50629, 51400}
+        set ANSI bright red color to {46003, 34438, 34438}
+        set ANSI bright green color to {34695, 46003, 34438}
+        set ANSI bright yellow color to {43690, 46003, 34438}
+        set ANSI bright blue color to {34438, 35980, 46003}
+        set ANSI bright magenta color to {46003, 34438, 45746}
+        set ANSI bright cyan color to {34438, 46003, 46003}
+        set ANSI bright white color to {18504, 22616, 26471}
+    end tell
+end tell
+EOF

--- a/scripts/base16-caroline.sh
+++ b/scripts/base16-caroline.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 4626, 4883}
+        set foreground color to {43176, 30069, 26985}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 4626, 4883}
+        set ANSI red color to {49858, 20303, 22359}
+        set ANSI green color to {32896, 27756, 24929}
+        set ANSI yellow color to {62194, 33153, 29041}
+        set ANSI blue color to {26728, 19532, 22873}
+        set ANSI magenta color to {42662, 13878, 20560}
+        set ANSI cyan color to {27499, 25957, 26214}
+        set ANSI white color to {50629, 36237, 31611}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22102, 14392, 14135}
+        set ANSI bright red color to {49858, 20303, 22359}
+        set ANSI bright green color to {32896, 27756, 24929}
+        set ANSI bright yellow color to {62194, 33153, 29041}
+        set ANSI bright blue color to {26728, 19532, 22873}
+        set ANSI bright magenta color to {42662, 13878, 20560}
+        set ANSI bright cyan color to {27499, 25957, 26214}
+        set ANSI bright white color to {58339, 42662, 35980}
+    end tell
+end tell
+EOF

--- a/scripts/base16-catppuccin-frappe.sh
+++ b/scripts/base16-catppuccin-frappe.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {12336, 13364, 17990}
+        set foreground color to {50886, 53456, 62965}
+
+        -- Set ANSI Colors
+        set ANSI black color to {12336, 13364, 17990}
+        set ANSI red color to {59367, 33410, 33924}
+        set ANSI green color to {42662, 53713, 35209}
+        set ANSI yellow color to {58853, 51400, 37008}
+        set ANSI blue color to {35980, 43690, 61166}
+        set ANSI magenta color to {51914, 40606, 59110}
+        set ANSI cyan color to {33153, 51400, 48830}
+        set ANSI white color to {62194, 54741, 53199}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16705, 17733, 22873}
+        set ANSI bright red color to {59367, 33410, 33924}
+        set ANSI bright green color to {42662, 53713, 35209}
+        set ANSI bright yellow color to {58853, 51400, 37008}
+        set ANSI bright blue color to {35980, 43690, 61166}
+        set ANSI bright magenta color to {51914, 40606, 59110}
+        set ANSI bright cyan color to {33153, 51400, 48830}
+        set ANSI bright white color to {47802, 48059, 61937}
+    end tell
+end tell
+EOF

--- a/scripts/base16-catppuccin-latte.sh
+++ b/scripts/base16-catppuccin-latte.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61423, 61937, 62965}
+        set foreground color to {19532, 20303, 26985}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61423, 61937, 62965}
+        set ANSI red color to {53970, 3855, 14649}
+        set ANSI green color to {16448, 41120, 11051}
+        set ANSI yellow color to {57311, 36494, 7453}
+        set ANSI blue color to {7710, 26214, 62965}
+        set ANSI magenta color to {34952, 14649, 61423}
+        set ANSI cyan color to {5911, 37522, 39321}
+        set ANSI white color to {56540, 35466, 30840}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {52428, 53456, 56026}
+        set ANSI bright red color to {53970, 3855, 14649}
+        set ANSI bright green color to {16448, 41120, 11051}
+        set ANSI bright yellow color to {57311, 36494, 7453}
+        set ANSI bright blue color to {7710, 26214, 62965}
+        set ANSI bright magenta color to {34952, 14649, 61423}
+        set ANSI bright cyan color to {5911, 37522, 39321}
+        set ANSI bright white color to {29298, 34695, 65021}
+    end tell
+end tell
+EOF

--- a/scripts/base16-catppuccin-macchiato.sh
+++ b/scripts/base16-catppuccin-macchiato.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9252, 10023, 14906}
+        set foreground color to {51914, 54227, 62965}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9252, 10023, 14906}
+        set ANSI red color to {60909, 34695, 38550}
+        set ANSI green color to {42662, 56026, 38293}
+        set ANSI yellow color to {61166, 54484, 40863}
+        set ANSI blue color to {35466, 44461, 62708}
+        set ANSI magenta color to {50886, 41120, 63222}
+        set ANSI cyan color to {35723, 54741, 51914}
+        set ANSI white color to {62708, 56283, 54998}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13878, 14906, 20303}
+        set ANSI bright red color to {60909, 34695, 38550}
+        set ANSI bright green color to {42662, 56026, 38293}
+        set ANSI bright yellow color to {61166, 54484, 40863}
+        set ANSI bright blue color to {35466, 44461, 62708}
+        set ANSI bright magenta color to {50886, 41120, 63222}
+        set ANSI bright cyan color to {35723, 54741, 51914}
+        set ANSI bright white color to {47031, 48573, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-catppuccin-mocha.sh
+++ b/scripts/base16-catppuccin-mocha.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7710, 7710, 11822}
+        set foreground color to {52685, 54998, 62708}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7710, 7710, 11822}
+        set ANSI red color to {62451, 35723, 43176}
+        set ANSI green color to {42662, 58339, 41377}
+        set ANSI yellow color to {63993, 58082, 44975}
+        set ANSI blue color to {35209, 46260, 64250}
+        set ANSI magenta color to {52171, 42662, 63479}
+        set ANSI cyan color to {38036, 58082, 54741}
+        set ANSI white color to {62965, 57568, 56540}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12593, 12850, 17476}
+        set ANSI bright red color to {62451, 35723, 43176}
+        set ANSI bright green color to {42662, 58339, 41377}
+        set ANSI bright yellow color to {63993, 58082, 44975}
+        set ANSI bright blue color to {35209, 46260, 64250}
+        set ANSI bright magenta color to {52171, 42662, 63479}
+        set ANSI bright cyan color to {38036, 58082, 54741}
+        set ANSI bright white color to {46260, 48830, 65278}
+    end tell
+end tell
+EOF

--- a/scripts/base16-chalk.sh
+++ b/scripts/base16-chalk.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5397, 5397, 5397}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5397, 5397, 5397}
+        set ANSI red color to {64507, 40863, 45489}
+        set ANSI green color to {44204, 49858, 26471}
+        set ANSI yellow color to {56797, 45746, 28527}
+        set ANSI blue color to {28527, 49858, 61423}
+        set ANSI magenta color to {57825, 41891, 61166}
+        set ANSI cyan color to {4626, 53199, 49344}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {64507, 40863, 45489}
+        set ANSI bright green color to {44204, 49858, 26471}
+        set ANSI bright yellow color to {56797, 45746, 28527}
+        set ANSI bright blue color to {28527, 49858, 61423}
+        set ANSI bright magenta color to {57825, 41891, 61166}
+        set ANSI bright cyan color to {4626, 53199, 49344}
+        set ANSI bright white color to {62965, 62965, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-circus.sh
+++ b/scripts/base16-circus.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6425, 6425, 6425}
+        set foreground color to {42919, 42919, 42919}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6425, 6425, 6425}
+        set ANSI red color to {56540, 25957, 32125}
+        set ANSI green color to {33924, 47545, 31868}
+        set ANSI yellow color to {50115, 47802, 25443}
+        set ANSI blue color to {25443, 40606, 58596}
+        set ANSI magenta color to {47288, 34952, 58082}
+        set ANSI cyan color to {19275, 45489, 42919}
+        set ANSI white color to {32896, 32896, 32896}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {56540, 25957, 32125}
+        set ANSI bright green color to {33924, 47545, 31868}
+        set ANSI bright yellow color to {50115, 47802, 25443}
+        set ANSI bright blue color to {25443, 40606, 58596}
+        set ANSI bright magenta color to {47288, 34952, 58082}
+        set ANSI bright cyan color to {19275, 45489, 42919}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-classic-dark.sh
+++ b/scripts/base16-classic-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5397, 5397, 5397}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5397, 5397, 5397}
+        set ANSI red color to {44204, 16705, 16962}
+        set ANSI green color to {37008, 43433, 22873}
+        set ANSI yellow color to {62708, 49087, 30069}
+        set ANSI blue color to {27242, 40863, 46517}
+        set ANSI magenta color to {43690, 30069, 40863}
+        set ANSI cyan color to {30069, 46517, 43690}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {44204, 16705, 16962}
+        set ANSI bright green color to {37008, 43433, 22873}
+        set ANSI bright yellow color to {62708, 49087, 30069}
+        set ANSI bright blue color to {27242, 40863, 46517}
+        set ANSI bright magenta color to {43690, 30069, 40863}
+        set ANSI bright cyan color to {30069, 46517, 43690}
+        set ANSI bright white color to {62965, 62965, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-classic-light.sh
+++ b/scripts/base16-classic-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62965, 62965, 62965}
+        set foreground color to {12336, 12336, 12336}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62965, 62965, 62965}
+        set ANSI red color to {44204, 16705, 16962}
+        set ANSI green color to {37008, 43433, 22873}
+        set ANSI yellow color to {62708, 49087, 30069}
+        set ANSI blue color to {27242, 40863, 46517}
+        set ANSI magenta color to {43690, 30069, 40863}
+        set ANSI cyan color to {30069, 46517, 43690}
+        set ANSI white color to {8224, 8224, 8224}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {53456, 53456, 53456}
+        set ANSI bright red color to {44204, 16705, 16962}
+        set ANSI bright green color to {37008, 43433, 22873}
+        set ANSI bright yellow color to {62708, 49087, 30069}
+        set ANSI bright blue color to {27242, 40863, 46517}
+        set ANSI bright magenta color to {43690, 30069, 40863}
+        set ANSI bright cyan color to {30069, 46517, 43690}
+        set ANSI bright white color to {5397, 5397, 5397}
+    end tell
+end tell
+EOF

--- a/scripts/base16-codeschool.sh
+++ b/scripts/base16-codeschool.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 11308, 12593}
+        set foreground color to {40606, 42919, 42662}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 11308, 12593}
+        set ANSI red color to {10794, 21588, 37265}
+        set ANSI green color to {8995, 31097, 34438}
+        set ANSI yellow color to {41120, 15163, 7710}
+        set ANSI blue color to {18504, 19789, 31097}
+        set ANSI magenta color to {50629, 39064, 8224}
+        set ANSI cyan color to {45232, 12079, 12336}
+        set ANSI white color to {42919, 53199, 41891}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10794, 13364, 14906}
+        set ANSI bright red color to {10794, 21588, 37265}
+        set ANSI bright green color to {8995, 31097, 34438}
+        set ANSI bright yellow color to {41120, 15163, 7710}
+        set ANSI bright blue color to {18504, 19789, 31097}
+        set ANSI bright magenta color to {50629, 39064, 8224}
+        set ANSI bright cyan color to {45232, 12079, 12336}
+        set ANSI bright white color to {46517, 55512, 63222}
+    end tell
+end tell
+EOF

--- a/scripts/base16-colors.sh
+++ b/scripts/base16-colors.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4369, 4369}
+        set foreground color to {48059, 48059, 48059}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4369, 4369}
+        set ANSI red color to {65535, 16705, 13878}
+        set ANSI green color to {11822, 52428, 16448}
+        set ANSI yellow color to {65535, 56540, 0}
+        set ANSI blue color to {0, 29812, 55769}
+        set ANSI magenta color to {45489, 3341, 51657}
+        set ANSI cyan color to {32639, 56283, 65535}
+        set ANSI white color to {56797, 56797, 56797}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21845, 21845, 21845}
+        set ANSI bright red color to {65535, 16705, 13878}
+        set ANSI bright green color to {11822, 52428, 16448}
+        set ANSI bright yellow color to {65535, 56540, 0}
+        set ANSI bright blue color to {0, 29812, 55769}
+        set ANSI bright magenta color to {45489, 3341, 51657}
+        set ANSI bright cyan color to {32639, 56283, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-cupcake.sh
+++ b/scripts/base16-cupcake.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 61937, 62194}
+        set foreground color to {35723, 33153, 39064}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 61937, 62194}
+        set ANSI red color to {54741, 32382, 34181}
+        set ANSI green color to {41891, 46003, 26471}
+        set ANSI yellow color to {56540, 45489, 27756}
+        set ANSI blue color to {29298, 38807, 47545}
+        set ANSI magenta color to {48059, 39321, 46260}
+        set ANSI cyan color to {26985, 43433, 42919}
+        set ANSI white color to {29298, 26471, 32382}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 54741, 56797}
+        set ANSI bright red color to {54741, 32382, 34181}
+        set ANSI bright green color to {41891, 46003, 26471}
+        set ANSI bright yellow color to {56540, 45489, 27756}
+        set ANSI bright blue color to {29298, 38807, 47545}
+        set ANSI bright magenta color to {48059, 39321, 46260}
+        set ANSI bright cyan color to {26985, 43433, 42919}
+        set ANSI bright white color to {22616, 20560, 25186}
+    end tell
+end tell
+EOF

--- a/scripts/base16-cupertino.sh
+++ b/scripts/base16-cupertino.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {16448, 16448, 16448}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {50372, 6682, 5397}
+        set ANSI green color to {0, 29812, 0}
+        set ANSI yellow color to {33410, 27499, 10280}
+        set ANSI blue color to {0, 0, 65535}
+        set ANSI magenta color to {43433, 3341, 37265}
+        set ANSI cyan color to {12593, 33924, 38293}
+        set ANSI white color to {16448, 16448, 16448}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {49344, 49344, 49344}
+        set ANSI bright red color to {50372, 6682, 5397}
+        set ANSI bright green color to {0, 29812, 0}
+        set ANSI bright yellow color to {33410, 27499, 10280}
+        set ANSI bright blue color to {0, 0, 65535}
+        set ANSI bright magenta color to {43433, 3341, 37265}
+        set ANSI bright cyan color to {12593, 33924, 38293}
+        set ANSI bright white color to {24158, 24158, 24158}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-black.sh
+++ b/scripts/base16-da-one-black.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {65535, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {64250, 30840, 33667}
+        set ANSI green color to {39064, 50115, 31097}
+        set ANSI yellow color to {65535, 38036, 28784}
+        set ANSI blue color to {27499, 47288, 65535}
+        set ANSI magenta color to {59367, 39321, 65535}
+        set ANSI cyan color to {35466, 62965, 65535}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 22616, 22616}
+        set ANSI bright red color to {64250, 30840, 33667}
+        set ANSI bright green color to {39064, 50115, 31097}
+        set ANSI bright yellow color to {65535, 38036, 28784}
+        set ANSI bright blue color to {27499, 47288, 65535}
+        set ANSI bright magenta color to {59367, 39321, 65535}
+        set ANSI bright cyan color to {35466, 62965, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-gray.sh
+++ b/scripts/base16-da-one-gray.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 6168, 6168}
+        set foreground color to {65535, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 6168, 6168}
+        set ANSI red color to {64250, 30840, 33667}
+        set ANSI green color to {39064, 50115, 31097}
+        set ANSI yellow color to {65535, 38036, 28784}
+        set ANSI blue color to {27499, 47288, 65535}
+        set ANSI magenta color to {59367, 39321, 65535}
+        set ANSI cyan color to {35466, 62965, 65535}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 22616, 22616}
+        set ANSI bright red color to {64250, 30840, 33667}
+        set ANSI bright green color to {39064, 50115, 31097}
+        set ANSI bright yellow color to {65535, 38036, 28784}
+        set ANSI bright blue color to {27499, 47288, 65535}
+        set ANSI bright magenta color to {59367, 39321, 65535}
+        set ANSI bright cyan color to {35466, 62965, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-ocean.sh
+++ b/scripts/base16-da-one-ocean.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 5911, 9766}
+        set foreground color to {65535, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 5911, 9766}
+        set ANSI red color to {64250, 30840, 33667}
+        set ANSI green color to {39064, 50115, 31097}
+        set ANSI yellow color to {65535, 38036, 28784}
+        set ANSI blue color to {27499, 47288, 65535}
+        set ANSI magenta color to {59367, 39321, 65535}
+        set ANSI cyan color to {35466, 62965, 65535}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21074, 22616, 26214}
+        set ANSI bright red color to {64250, 30840, 33667}
+        set ANSI bright green color to {39064, 50115, 31097}
+        set ANSI bright yellow color to {65535, 38036, 28784}
+        set ANSI bright blue color to {27499, 47288, 65535}
+        set ANSI bright magenta color to {59367, 39321, 65535}
+        set ANSI bright cyan color to {35466, 62965, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-paper.sh
+++ b/scripts/base16-da-one-paper.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 61680, 56540}
+        set foreground color to {6168, 6168, 6168}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 61680, 56540}
+        set ANSI red color to {57054, 23901, 28270}
+        set ANSI green color to {30326, 43176, 23901}
+        set ANSI yellow color to {46003, 26728, 20303}
+        set ANSI blue color to {22616, 37008, 63736}
+        set ANSI magenta color to {49601, 29555, 53713}
+        set ANSI cyan color to {25700, 46517, 42919}
+        set ANSI white color to {0, 0, 0}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {34952, 34952, 34952}
+        set ANSI bright red color to {57054, 23901, 28270}
+        set ANSI bright green color to {30326, 43176, 23901}
+        set ANSI bright yellow color to {46003, 26728, 20303}
+        set ANSI bright blue color to {22616, 37008, 63736}
+        set ANSI bright magenta color to {49601, 29555, 53713}
+        set ANSI bright cyan color to {25700, 46517, 42919}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-sea.sh
+++ b/scripts/base16-da-one-sea.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 10023, 15677}
+        set foreground color to {65535, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 10023, 15677}
+        set ANSI red color to {64250, 30840, 33667}
+        set ANSI green color to {39064, 50115, 31097}
+        set ANSI yellow color to {65535, 38036, 28784}
+        set ANSI blue color to {27499, 47288, 65535}
+        set ANSI magenta color to {59367, 39321, 65535}
+        set ANSI cyan color to {35466, 62965, 65535}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21074, 22616, 26214}
+        set ANSI bright red color to {64250, 30840, 33667}
+        set ANSI bright green color to {39064, 50115, 31097}
+        set ANSI bright yellow color to {65535, 38036, 28784}
+        set ANSI bright blue color to {27499, 47288, 65535}
+        set ANSI bright magenta color to {59367, 39321, 65535}
+        set ANSI bright cyan color to {35466, 62965, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-da-one-white.sh
+++ b/scripts/base16-da-one-white.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {6168, 6168, 6168}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {57054, 23901, 28270}
+        set ANSI green color to {30326, 43176, 23901}
+        set ANSI yellow color to {46003, 26728, 20303}
+        set ANSI blue color to {22616, 37008, 63736}
+        set ANSI magenta color to {49601, 29555, 53713}
+        set ANSI cyan color to {25700, 46517, 42919}
+        set ANSI white color to {0, 0, 0}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {34952, 34952, 34952}
+        set ANSI bright red color to {57054, 23901, 28270}
+        set ANSI bright green color to {30326, 43176, 23901}
+        set ANSI bright yellow color to {46003, 26728, 20303}
+        set ANSI bright blue color to {22616, 37008, 63736}
+        set ANSI bright magenta color to {49601, 29555, 53713}
+        set ANSI bright cyan color to {25700, 46517, 42919}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-danqing-light.sh
+++ b/scripts/base16-danqing-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64764, 65278, 65021}
+        set foreground color to {23130, 24672, 23901}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64764, 65278, 65021}
+        set ANSI red color to {63993, 37008, 28527}
+        set ANSI green color to {35466, 46003, 24929}
+        set ANSI yellow color to {61680, 49858, 14649}
+        set ANSI blue color to {45232, 42148, 58339}
+        set ANSI magenta color to {52428, 42148, 58339}
+        set ANSI cyan color to {12336, 57311, 62451}
+        set ANSI white color to {17219, 18504, 17990}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57568, 61680, 61423}
+        set ANSI bright red color to {63993, 37008, 28527}
+        set ANSI bright green color to {35466, 46003, 24929}
+        set ANSI bright yellow color to {61680, 49858, 14649}
+        set ANSI bright blue color to {45232, 42148, 58339}
+        set ANSI bright magenta color to {52428, 42148, 58339}
+        set ANSI bright cyan color to {12336, 57311, 62451}
+        set ANSI bright white color to {11565, 12336, 12079}
+    end tell
+end tell
+EOF

--- a/scripts/base16-danqing.sh
+++ b/scripts/base16-danqing.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 12336, 12079}
+        set foreground color to {57568, 61680, 61423}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 12336, 12079}
+        set ANSI red color to {63993, 37008, 28527}
+        set ANSI green color to {35466, 46003, 24929}
+        set ANSI yellow color to {61680, 49858, 14649}
+        set ANSI blue color to {45232, 42148, 58339}
+        set ANSI magenta color to {52428, 42148, 58339}
+        set ANSI cyan color to {12336, 57311, 62451}
+        set ANSI white color to {60652, 63222, 62194}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 24672, 23901}
+        set ANSI bright red color to {63993, 37008, 28527}
+        set ANSI bright green color to {35466, 46003, 24929}
+        set ANSI bright yellow color to {61680, 49858, 14649}
+        set ANSI bright blue color to {45232, 42148, 58339}
+        set ANSI bright magenta color to {52428, 42148, 58339}
+        set ANSI bright cyan color to {12336, 57311, 62451}
+        set ANSI bright white color to {64764, 65278, 65021}
+    end tell
+end tell
+EOF

--- a/scripts/base16-darcula.sh
+++ b/scripts/base16-darcula.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11051, 11051, 11051}
+        set foreground color to {43433, 47031, 50886}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11051, 11051, 11051}
+        set ANSI red color to {20046, 44461, 58853}
+        set ANSI green color to {27242, 34695, 22873}
+        set ANSI yellow color to {48059, 46517, 10537}
+        set ANSI blue color to {39064, 30326, 43690}
+        set ANSI magenta color to {52428, 30840, 12850}
+        set ANSI cyan color to {25186, 38807, 21845}
+        set ANSI white color to {65535, 50886, 28013}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12850, 12850, 12850}
+        set ANSI bright red color to {20046, 44461, 58853}
+        set ANSI bright green color to {27242, 34695, 22873}
+        set ANSI bright yellow color to {48059, 46517, 10537}
+        set ANSI bright blue color to {39064, 30326, 43690}
+        set ANSI bright magenta color to {52428, 30840, 12850}
+        set ANSI bright cyan color to {25186, 38807, 21845}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-darkmoss.sh
+++ b/scripts/base16-darkmoss.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 7710, 7967}
+        set foreground color to {51143, 51143, 42405}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 7710, 7967}
+        set ANSI red color to {65535, 17990, 22616}
+        set ANSI green color to {18761, 37265, 32896}
+        set ANSI yellow color to {65021, 45489, 7967}
+        set ANSI blue color to {18761, 32896, 37265}
+        set ANSI magenta color to {39835, 49344, 51400}
+        set ANSI cyan color to {26214, 55769, 61423}
+        set ANSI white color to {58339, 58339, 51400}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14135, 15420, 15677}
+        set ANSI bright red color to {65535, 17990, 22616}
+        set ANSI bright green color to {18761, 37265, 32896}
+        set ANSI bright yellow color to {65021, 45489, 7967}
+        set ANSI bright blue color to {18761, 32896, 37265}
+        set ANSI bright magenta color to {39835, 49344, 51400}
+        set ANSI bright cyan color to {26214, 55769, 61423}
+        set ANSI bright white color to {57825, 60138, 61423}
+    end tell
+end tell
+EOF

--- a/scripts/base16-darktooth.sh
+++ b/scripts/base16-darktooth.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7453, 8224, 8481}
+        set foreground color to {43176, 39321, 33924}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7453, 8224, 8481}
+        set ANSI red color to {64507, 21588, 16191}
+        set ANSI green color to {38293, 49344, 34181}
+        set ANSI yellow color to {64250, 49344, 15163}
+        set ANSI blue color to {3341, 26214, 30840}
+        set ANSI magenta color to {36751, 17990, 29555}
+        set ANSI cyan color to {35723, 42405, 39835}
+        set ANSI white color to {54741, 50372, 41377}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {64507, 21588, 16191}
+        set ANSI bright green color to {38293, 49344, 34181}
+        set ANSI bright yellow color to {64250, 49344, 15163}
+        set ANSI bright blue color to {3341, 26214, 30840}
+        set ANSI bright magenta color to {36751, 17990, 29555}
+        set ANSI bright cyan color to {35723, 42405, 39835}
+        set ANSI bright white color to {65021, 62708, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-darkviolet.sh
+++ b/scripts/base16-darkviolet.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {45232, 35466, 59110}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {43176, 11822, 59110}
+        set ANSI green color to {17733, 38293, 59110}
+        set ANSI yellow color to {62194, 40349, 62194}
+        set ANSI blue color to {16705, 13878, 55769}
+        set ANSI magenta color to {32382, 23644, 59110}
+        set ANSI cyan color to {16448, 57311, 65535}
+        set ANSI white color to {37008, 17733, 59110}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17219, 11565, 22873}
+        set ANSI bright red color to {43176, 11822, 59110}
+        set ANSI bright green color to {17733, 38293, 59110}
+        set ANSI bright yellow color to {62194, 40349, 62194}
+        set ANSI bright blue color to {16705, 13878, 55769}
+        set ANSI bright magenta color to {32382, 23644, 59110}
+        set ANSI bright cyan color to {16448, 57311, 65535}
+        set ANSI bright white color to {41891, 26214, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-decaf.sh
+++ b/scripts/base16-decaf.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 11565, 11565}
+        set foreground color to {52428, 52428, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 11565, 11565}
+        set ANSI red color to {65535, 32639, 31611}
+        set ANSI green color to {48830, 56026, 30840}
+        set ANSI yellow color to {65535, 54998, 31868}
+        set ANSI blue color to {37008, 48830, 57825}
+        set ANSI magenta color to {61423, 46003, 63479}
+        set ANSI cyan color to {48830, 54998, 65535}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 20817, 20817}
+        set ANSI bright red color to {65535, 32639, 31611}
+        set ANSI bright green color to {48830, 56026, 30840}
+        set ANSI bright yellow color to {65535, 54998, 31868}
+        set ANSI bright blue color to {37008, 48830, 57825}
+        set ANSI bright magenta color to {61423, 46003, 63479}
+        set ANSI bright cyan color to {48830, 54998, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-default-dark.sh
+++ b/scripts/base16-default-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 6168, 6168}
+        set foreground color to {55512, 55512, 55512}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 6168, 6168}
+        set ANSI red color to {43947, 17990, 16962}
+        set ANSI green color to {41377, 46517, 27756}
+        set ANSI yellow color to {63479, 51914, 34952}
+        set ANSI blue color to {31868, 44975, 49858}
+        set ANSI magenta color to {47802, 35723, 44975}
+        set ANSI cyan color to {34438, 49601, 47545}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14392, 14392, 14392}
+        set ANSI bright red color to {43947, 17990, 16962}
+        set ANSI bright green color to {41377, 46517, 27756}
+        set ANSI bright yellow color to {63479, 51914, 34952}
+        set ANSI bright blue color to {31868, 44975, 49858}
+        set ANSI bright magenta color to {47802, 35723, 44975}
+        set ANSI bright cyan color to {34438, 49601, 47545}
+        set ANSI bright white color to {63736, 63736, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-default-light.sh
+++ b/scripts/base16-default-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63736, 63736, 63736}
+        set foreground color to {14392, 14392, 14392}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63736, 63736, 63736}
+        set ANSI red color to {43947, 17990, 16962}
+        set ANSI green color to {41377, 46517, 27756}
+        set ANSI yellow color to {63479, 51914, 34952}
+        set ANSI blue color to {31868, 44975, 49858}
+        set ANSI magenta color to {47802, 35723, 44975}
+        set ANSI cyan color to {34438, 49601, 47545}
+        set ANSI white color to {10280, 10280, 10280}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 55512, 55512}
+        set ANSI bright red color to {43947, 17990, 16962}
+        set ANSI bright green color to {41377, 46517, 27756}
+        set ANSI bright yellow color to {63479, 51914, 34952}
+        set ANSI bright blue color to {31868, 44975, 49858}
+        set ANSI bright magenta color to {47802, 35723, 44975}
+        set ANSI bright cyan color to {34438, 49601, 47545}
+        set ANSI bright white color to {6168, 6168, 6168}
+    end tell
+end tell
+EOF

--- a/scripts/base16-dirtysea.sh
+++ b/scripts/base16-dirtysea.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {57568, 57568, 57568}
+        set foreground color to {0, 0, 0}
+
+        -- Set ANSI Colors
+        set ANSI black color to {57568, 57568, 57568}
+        set ANSI red color to {33924, 0, 0}
+        set ANSI green color to {29555, 0, 29555}
+        set ANSI yellow color to {30069, 23387, 0}
+        set ANSI blue color to {0, 29555, 0}
+        set ANSI magenta color to {0, 0, 37008}
+        set ANSI cyan color to {30069, 23387, 0}
+        set ANSI white color to {63736, 63736, 63736}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {53456, 53456, 53456}
+        set ANSI bright red color to {33924, 0, 0}
+        set ANSI bright green color to {29555, 0, 29555}
+        set ANSI bright yellow color to {30069, 23387, 0}
+        set ANSI bright blue color to {0, 29555, 0}
+        set ANSI bright magenta color to {0, 0, 37008}
+        set ANSI bright cyan color to {30069, 23387, 0}
+        set ANSI bright white color to {50372, 55769, 50372}
+    end tell
+end tell
+EOF

--- a/scripts/base16-dracula.sh
+++ b/scripts/base16-dracula.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 10794, 13878}
+        set foreground color to {63736, 63736, 62194}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 10794, 13878}
+        set ANSI red color to {65535, 21845, 21845}
+        set ANSI green color to {20560, 64250, 31611}
+        set ANSI yellow color to {61937, 64250, 35980}
+        set ANSI blue color to {32896, 49087, 65535}
+        set ANSI magenta color to {65535, 31097, 50886}
+        set ANSI cyan color to {35723, 59881, 65021}
+        set ANSI white color to {61680, 61937, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17476, 18247, 23130}
+        set ANSI bright red color to {65535, 21845, 21845}
+        set ANSI bright green color to {20560, 64250, 31611}
+        set ANSI bright yellow color to {61937, 64250, 35980}
+        set ANSI bright blue color to {32896, 49087, 65535}
+        set ANSI bright magenta color to {65535, 31097, 50886}
+        set ANSI bright cyan color to {35723, 59881, 65021}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-edge-dark.sh
+++ b/scripts/base16-edge-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 10023, 10537}
+        set foreground color to {47031, 48830, 51657}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 10023, 10537}
+        set ANSI red color to {59367, 29041, 29041}
+        set ANSI green color to {41377, 49087, 30840}
+        set ANSI yellow color to {56283, 47031, 29812}
+        set ANSI blue color to {29555, 46003, 59367}
+        set ANSI magenta color to {54227, 37008, 59367}
+        set ANSI cyan color to {24158, 47802, 42405}
+        set ANSI white color to {54227, 37008, 59367}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {47031, 48830, 51657}
+        set ANSI bright red color to {59367, 29041, 29041}
+        set ANSI bright green color to {41377, 49087, 30840}
+        set ANSI bright yellow color to {56283, 47031, 29812}
+        set ANSI bright blue color to {29555, 46003, 59367}
+        set ANSI bright magenta color to {54227, 37008, 59367}
+        set ANSI bright cyan color to {24158, 47802, 42405}
+        set ANSI bright white color to {15934, 16962, 18761}
+    end tell
+end tell
+EOF

--- a/scripts/base16-edge-light.sh
+++ b/scripts/base16-edge-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 64250, 64250}
+        set foreground color to {24158, 25700, 28527}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 64250, 64250}
+        set ANSI red color to {56283, 28784, 28784}
+        set ANSI green color to {31868, 40863, 19275}
+        set ANSI yellow color to {54998, 39064, 8738}
+        set ANSI blue color to {25957, 34695, 49087}
+        set ANSI magenta color to {47288, 28784, 52942}
+        set ANSI cyan color to {20560, 40092, 37779}
+        set ANSI white color to {47288, 28784, 52942}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54998, 39064, 8738}
+        set ANSI bright red color to {56283, 28784, 28784}
+        set ANSI bright green color to {31868, 40863, 19275}
+        set ANSI bright yellow color to {54998, 39064, 8738}
+        set ANSI bright blue color to {25957, 34695, 49087}
+        set ANSI bright magenta color to {47288, 28784, 52942}
+        set ANSI bright cyan color to {20560, 40092, 37779}
+        set ANSI bright white color to {24158, 25700, 28527}
+    end tell
+end tell
+EOF

--- a/scripts/base16-eighties.sh
+++ b/scripts/base16-eighties.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 11565, 11565}
+        set foreground color to {54227, 53456, 51400}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 11565, 11565}
+        set ANSI red color to {62194, 30583, 31354}
+        set ANSI green color to {39321, 52428, 39321}
+        set ANSI yellow color to {65535, 52428, 26214}
+        set ANSI blue color to {26214, 39321, 52428}
+        set ANSI magenta color to {52428, 39321, 52428}
+        set ANSI cyan color to {26214, 52428, 52428}
+        set ANSI white color to {59624, 59110, 57311}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 20817, 20817}
+        set ANSI bright red color to {62194, 30583, 31354}
+        set ANSI bright green color to {39321, 52428, 39321}
+        set ANSI bright yellow color to {65535, 52428, 26214}
+        set ANSI bright blue color to {26214, 39321, 52428}
+        set ANSI bright magenta color to {52428, 39321, 52428}
+        set ANSI bright cyan color to {26214, 52428, 52428}
+        set ANSI bright white color to {62194, 61680, 60652}
+    end tell
+end tell
+EOF

--- a/scripts/base16-embers-light.sh
+++ b/scripts/base16-embers-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {53713, 54998, 56283}
+        set foreground color to {12850, 15163, 17219}
+
+        -- Set ANSI Colors
+        set ANSI black color to {53713, 54998, 56283}
+        set ANSI red color to {22359, 28013, 33410}
+        set ANSI green color to {28013, 33410, 22359}
+        set ANSI yellow color to {22359, 33410, 28013}
+        set ANSI blue color to {33410, 22359, 28013}
+        set ANSI magenta color to {28013, 22359, 33410}
+        set ANSI cyan color to {33410, 28013, 22359}
+        set ANSI white color to {8224, 9766, 11308}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {37008, 39578, 41891}
+        set ANSI bright red color to {22359, 28013, 33410}
+        set ANSI bright green color to {28013, 33410, 22359}
+        set ANSI bright yellow color to {22359, 33410, 28013}
+        set ANSI bright blue color to {33410, 22359, 28013}
+        set ANSI bright magenta color to {28013, 22359, 33410}
+        set ANSI bright cyan color to {33410, 28013, 22359}
+        set ANSI bright white color to {3855, 4883, 5654}
+    end tell
+end tell
+EOF

--- a/scripts/base16-embers.sh
+++ b/scripts/base16-embers.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5654, 4883, 3855}
+        set foreground color to {41891, 39578, 37008}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5654, 4883, 3855}
+        set ANSI red color to {33410, 28013, 22359}
+        set ANSI green color to {22359, 33410, 28013}
+        set ANSI yellow color to {28013, 33410, 22359}
+        set ANSI blue color to {28013, 22359, 33410}
+        set ANSI magenta color to {33410, 22359, 28013}
+        set ANSI cyan color to {22359, 28013, 33410}
+        set ANSI white color to {48830, 46774, 44718}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17219, 15163, 12850}
+        set ANSI bright red color to {33410, 28013, 22359}
+        set ANSI bright green color to {22359, 33410, 28013}
+        set ANSI bright yellow color to {28013, 33410, 22359}
+        set ANSI bright blue color to {28013, 22359, 33410}
+        set ANSI bright magenta color to {33410, 22359, 28013}
+        set ANSI bright cyan color to {22359, 28013, 33410}
+        set ANSI bright white color to {56283, 54998, 53713}
+    end tell
+end tell
+EOF

--- a/scripts/base16-emil.sh
+++ b/scripts/base16-emil.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61423, 61423, 61423}
+        set foreground color to {12593, 12593, 17733}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61423, 61423, 61423}
+        set ANSI red color to {62708, 14649, 31097}
+        set ANSI green color to {0, 29555, 43176}
+        set ANSI yellow color to {65535, 26214, 39835}
+        set ANSI blue color to {18247, 4883, 38807}
+        set ANSI magenta color to {26985, 5654, 46774}
+        set ANSI cyan color to {8481, 21845, 54998}
+        set ANSI white color to {8738, 8738, 14906}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {40606, 40606, 44975}
+        set ANSI bright red color to {62708, 14649, 31097}
+        set ANSI bright green color to {0, 29555, 43176}
+        set ANSI bright yellow color to {65535, 26214, 39835}
+        set ANSI bright blue color to {18247, 4883, 38807}
+        set ANSI bright magenta color to {26985, 5654, 46774}
+        set ANSI bright cyan color to {8481, 21845, 54998}
+        set ANSI bright white color to {6682, 6682, 12079}
+    end tell
+end tell
+EOF

--- a/scripts/base16-equilibrium-dark.sh
+++ b/scripts/base16-equilibrium-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3084, 4369, 6168}
+        set foreground color to {44975, 43947, 41634}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3084, 4369, 6168}
+        set ANSI red color to {61680, 17219, 14649}
+        set ANSI green color to {32639, 35723, 0}
+        set ANSI yellow color to {48059, 34952, 257}
+        set ANSI blue color to {0, 36237, 53713}
+        set ANSI magenta color to {27242, 32639, 53970}
+        set ANSI cyan color to {0, 38036, 35723}
+        set ANSI white color to {51914, 50886, 48573}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 9766, 11565}
+        set ANSI bright red color to {61680, 17219, 14649}
+        set ANSI bright green color to {32639, 35723, 0}
+        set ANSI bright yellow color to {48059, 34952, 257}
+        set ANSI bright blue color to {0, 36237, 53713}
+        set ANSI bright magenta color to {27242, 32639, 53970}
+        set ANSI bright cyan color to {0, 38036, 35723}
+        set ANSI bright white color to {59367, 58082, 55769}
+    end tell
+end tell
+EOF

--- a/scripts/base16-equilibrium-gray-dark.sh
+++ b/scripts/base16-equilibrium-gray-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4369, 4369}
+        set foreground color to {43947, 43947, 43947}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4369, 4369}
+        set ANSI red color to {61680, 17219, 14649}
+        set ANSI green color to {32639, 35723, 0}
+        set ANSI yellow color to {48059, 34952, 257}
+        set ANSI blue color to {0, 36237, 53713}
+        set ANSI magenta color to {27242, 32639, 53970}
+        set ANSI cyan color to {0, 38036, 35723}
+        set ANSI white color to {50886, 50886, 50886}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {9766, 9766, 9766}
+        set ANSI bright red color to {61680, 17219, 14649}
+        set ANSI bright green color to {32639, 35723, 0}
+        set ANSI bright yellow color to {48059, 34952, 257}
+        set ANSI bright blue color to {0, 36237, 53713}
+        set ANSI bright magenta color to {27242, 32639, 53970}
+        set ANSI bright cyan color to {0, 38036, 35723}
+        set ANSI bright white color to {58082, 58082, 58082}
+    end tell
+end tell
+EOF

--- a/scripts/base16-equilibrium-gray-light.sh
+++ b/scripts/base16-equilibrium-gray-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61937, 61937, 61937}
+        set foreground color to {18247, 18247, 18247}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61937, 61937, 61937}
+        set ANSI red color to {53456, 8224, 8995}
+        set ANSI green color to {25443, 29298, 0}
+        set ANSI yellow color to {40349, 28527, 0}
+        set ANSI blue color to {0, 29555, 46517}
+        set ANSI magenta color to {20046, 26214, 46774}
+        set ANSI cyan color to {0, 31354, 29298}
+        set ANSI white color to {12336, 12336, 12336}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54484, 54484, 54484}
+        set ANSI bright red color to {53456, 8224, 8995}
+        set ANSI bright green color to {25443, 29298, 0}
+        set ANSI bright yellow color to {40349, 28527, 0}
+        set ANSI bright blue color to {0, 29555, 46517}
+        set ANSI bright magenta color to {20046, 26214, 46774}
+        set ANSI bright cyan color to {0, 31354, 29298}
+        set ANSI bright white color to {6939, 6939, 6939}
+    end tell
+end tell
+EOF

--- a/scripts/base16-equilibrium-light.sh
+++ b/scripts/base16-equilibrium-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62965, 61680, 59367}
+        set foreground color to {17219, 18247, 20046}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62965, 61680, 59367}
+        set ANSI red color to {53456, 8224, 8995}
+        set ANSI green color to {25443, 29298, 0}
+        set ANSI yellow color to {40349, 28527, 0}
+        set ANSI blue color to {0, 29555, 46517}
+        set ANSI magenta color to {20046, 26214, 46774}
+        set ANSI cyan color to {0, 31354, 29298}
+        set ANSI white color to {11308, 12593, 14392}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 54484, 52171}
+        set ANSI bright red color to {53456, 8224, 8995}
+        set ANSI bright green color to {25443, 29298, 0}
+        set ANSI bright yellow color to {40349, 28527, 0}
+        set ANSI bright blue color to {0, 29555, 46517}
+        set ANSI bright magenta color to {20046, 26214, 46774}
+        set ANSI bright cyan color to {0, 31354, 29298}
+        set ANSI bright white color to {6168, 7196, 8738}
+    end tell
+end tell
+EOF

--- a/scripts/base16-eris.sh
+++ b/scripts/base16-eris.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {2570, 2313, 8224}
+        set foreground color to {24672, 27499, 44204}
+
+        -- Set ANSI Colors
+        set ANSI black color to {2570, 2313, 8224}
+        set ANSI red color to {63479, 26728, 41891}
+        set ANSI green color to {64250, 44718, 41634}
+        set ANSI yellow color to {64250, 44718, 41634}
+        set ANSI blue color to {9509, 36751, 50372}
+        set ANSI magenta color to {63479, 26728, 41891}
+        set ANSI cyan color to {9509, 36751, 50372}
+        set ANSI white color to {31097, 34438, 50629}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8995, 9509, 23130}
+        set ANSI bright red color to {63479, 26728, 41891}
+        set ANSI bright green color to {64250, 44718, 41634}
+        set ANSI bright yellow color to {64250, 44718, 41634}
+        set ANSI bright blue color to {9509, 36751, 50372}
+        set ANSI bright magenta color to {63479, 26728, 41891}
+        set ANSI bright cyan color to {9509, 36751, 50372}
+        set ANSI bright white color to {39578, 43690, 58853}
+    end tell
+end tell
+EOF

--- a/scripts/base16-espresso.sh
+++ b/scripts/base16-espresso.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 11565, 11565}
+        set foreground color to {52428, 52428, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 11565, 11565}
+        set ANSI red color to {53970, 21074, 21074}
+        set ANSI green color to {42405, 49858, 24929}
+        set ANSI yellow color to {65535, 50886, 28013}
+        set ANSI blue color to {27756, 39321, 48059}
+        set ANSI magenta color to {53713, 38807, 55769}
+        set ANSI cyan color to {48830, 54998, 65535}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 20817, 20817}
+        set ANSI bright red color to {53970, 21074, 21074}
+        set ANSI bright green color to {42405, 49858, 24929}
+        set ANSI bright yellow color to {65535, 50886, 28013}
+        set ANSI bright blue color to {27756, 39321, 48059}
+        set ANSI bright magenta color to {53713, 38807, 55769}
+        set ANSI bright cyan color to {48830, 54998, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-eva-dim.sh
+++ b/scripts/base16-eva-dim.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10794, 15163, 19789}
+        set foreground color to {40863, 41634, 42662}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10794, 15163, 19789}
+        set ANSI red color to {50372, 26471, 27756}
+        set ANSI green color to {23901, 58853, 24929}
+        set ANSI yellow color to {53199, 53456, 23901}
+        set ANSI blue color to {6682, 57825, 56540}
+        set ANSI magenta color to {40092, 27756, 54227}
+        set ANSI cyan color to {19275, 36751, 30583}
+        set ANSI white color to {54998, 55255, 55769}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19275, 26985, 34952}
+        set ANSI bright red color to {50372, 26471, 27756}
+        set ANSI bright green color to {23901, 58853, 24929}
+        set ANSI bright yellow color to {53199, 53456, 23901}
+        set ANSI bright blue color to {6682, 57825, 56540}
+        set ANSI bright magenta color to {40092, 27756, 54227}
+        set ANSI bright cyan color to {19275, 36751, 30583}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-eva.sh
+++ b/scripts/base16-eva.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10794, 15163, 19789}
+        set foreground color to {40863, 41634, 42662}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10794, 15163, 19789}
+        set ANSI red color to {50372, 26471, 27756}
+        set ANSI green color to {26214, 65535, 26214}
+        set ANSI yellow color to {65535, 65535, 26214}
+        set ANSI blue color to {5397, 62708, 61166}
+        set ANSI magenta color to {40092, 27756, 54227}
+        set ANSI cyan color to {19275, 36751, 30583}
+        set ANSI white color to {54998, 55255, 55769}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19275, 26985, 34952}
+        set ANSI bright red color to {50372, 26471, 27756}
+        set ANSI bright green color to {26214, 65535, 26214}
+        set ANSI bright yellow color to {65535, 65535, 26214}
+        set ANSI bright blue color to {5397, 62708, 61166}
+        set ANSI bright magenta color to {40092, 27756, 54227}
+        set ANSI bright cyan color to {19275, 36751, 30583}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-evenok-dark.sh
+++ b/scripts/base16-evenok-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {62965, 28784, 35466}
+        set ANSI green color to {21588, 48316, 23644}
+        set ANSI yellow color to {47288, 41891, 0}
+        set ANSI blue color to {0, 44975, 62194}
+        set ANSI magenta color to {37008, 38293, 65535}
+        set ANSI cyan color to {0, 47802, 46003}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {62965, 28784, 35466}
+        set ANSI bright green color to {21588, 48316, 23644}
+        set ANSI bright yellow color to {47288, 41891, 0}
+        set ANSI bright blue color to {0, 44975, 62194}
+        set ANSI bright magenta color to {37008, 38293, 65535}
+        set ANSI bright cyan color to {0, 47802, 46003}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-everforest-dark-hard.sh
+++ b/scripts/base16-everforest-dark-hard.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10023, 11822, 13107}
+        set foreground color to {54227, 50886, 43690}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10023, 11822, 13107}
+        set ANSI red color to {59110, 32382, 32896}
+        set ANSI green color to {42919, 49344, 32896}
+        set ANSI yellow color to {56283, 48316, 32639}
+        set ANSI blue color to {32639, 48059, 46003}
+        set ANSI magenta color to {54998, 39321, 46774}
+        set ANSI cyan color to {33667, 49344, 37522}
+        set ANSI white color to {60909, 60138, 56026}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16705, 19275, 20560}
+        set ANSI bright red color to {59110, 32382, 32896}
+        set ANSI bright green color to {42919, 49344, 32896}
+        set ANSI bright yellow color to {56283, 48316, 32639}
+        set ANSI bright blue color to {32639, 48059, 46003}
+        set ANSI bright magenta color to {54998, 39321, 46774}
+        set ANSI bright cyan color to {33667, 49344, 37522}
+        set ANSI bright white color to {65535, 64507, 61423}
+    end tell
+end tell
+EOF

--- a/scripts/base16-everforest.sh
+++ b/scripts/base16-everforest.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 13621, 15163}
+        set foreground color to {54227, 50886, 43690}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 13621, 15163}
+        set ANSI red color to {59110, 32382, 32896}
+        set ANSI green color to {42919, 49344, 32896}
+        set ANSI yellow color to {56283, 48316, 32639}
+        set ANSI blue color to {32639, 48059, 46003}
+        set ANSI magenta color to {54998, 39321, 46774}
+        set ANSI cyan color to {33667, 49344, 37522}
+        set ANSI white color to {59110, 58082, 52428}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18247, 21074, 22616}
+        set ANSI bright red color to {59110, 32382, 32896}
+        set ANSI bright green color to {42919, 49344, 32896}
+        set ANSI bright yellow color to {56283, 48316, 32639}
+        set ANSI bright blue color to {32639, 48059, 46003}
+        set ANSI bright magenta color to {54998, 39321, 46774}
+        set ANSI bright cyan color to {33667, 49344, 37522}
+        set ANSI bright white color to {65021, 63222, 58339}
+    end tell
+end tell
+EOF

--- a/scripts/base16-flat.sh
+++ b/scripts/base16-flat.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11308, 15934, 20560}
+        set foreground color to {57568, 57568, 57568}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11308, 15934, 20560}
+        set ANSI red color to {59367, 19532, 15420}
+        set ANSI green color to {11822, 52428, 29041}
+        set ANSI yellow color to {61937, 50372, 3855}
+        set ANSI blue color to {13364, 39064, 56283}
+        set ANSI magenta color to {39835, 22873, 46774}
+        set ANSI cyan color to {6682, 48316, 40092}
+        set ANSI white color to {62965, 62965, 62965}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {32639, 35980, 36237}
+        set ANSI bright red color to {59367, 19532, 15420}
+        set ANSI bright green color to {11822, 52428, 29041}
+        set ANSI bright yellow color to {61937, 50372, 3855}
+        set ANSI bright blue color to {13364, 39064, 56283}
+        set ANSI bright magenta color to {39835, 22873, 46774}
+        set ANSI bright cyan color to {6682, 48316, 40092}
+        set ANSI bright white color to {60652, 61680, 61937}
+    end tell
+end tell
+EOF

--- a/scripts/base16-framer.sh
+++ b/scripts/base16-framer.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 6168, 6168}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 6168, 6168}
+        set ANSI red color to {65021, 34952, 27499}
+        set ANSI green color to {12850, 52428, 56540}
+        set ANSI yellow color to {65278, 52171, 28270}
+        set ANSI blue color to {8224, 48316, 64764}
+        set ANSI magenta color to {47802, 35980, 64764}
+        set ANSI cyan color to {44204, 56797, 65021}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17990, 17990, 17990}
+        set ANSI bright red color to {65021, 34952, 27499}
+        set ANSI bright green color to {12850, 52428, 56540}
+        set ANSI bright yellow color to {65278, 52171, 28270}
+        set ANSI bright blue color to {8224, 48316, 64764}
+        set ANSI bright magenta color to {47802, 35980, 64764}
+        set ANSI bright cyan color to {44204, 56797, 65021}
+        set ANSI bright white color to {61166, 61166, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-fruit-soda.sh
+++ b/scripts/base16-fruit-soda.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61937, 60652, 61937}
+        set foreground color to {20817, 20817, 20817}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61937, 60652, 61937}
+        set ANSI red color to {65278, 15934, 12593}
+        set ANSI green color to {18247, 63479, 19532}
+        set ANSI yellow color to {63479, 58082, 771}
+        set ANSI blue color to {10537, 12593, 57311}
+        set ANSI magenta color to {24929, 7967, 52942}
+        set ANSI cyan color to {3855, 40092, 65021}
+        set ANSI white color to {18247, 17733, 17733}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 54741, 54741}
+        set ANSI bright red color to {65278, 15934, 12593}
+        set ANSI bright green color to {18247, 63479, 19532}
+        set ANSI bright yellow color to {63479, 58082, 771}
+        set ANSI bright blue color to {10537, 12593, 57311}
+        set ANSI bright magenta color to {24929, 7967, 52942}
+        set ANSI bright cyan color to {3855, 40092, 65021}
+        set ANSI bright white color to {11565, 11308, 11308}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gigavolt.sh
+++ b/scripts/base16-gigavolt.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 8481, 9766}
+        set foreground color to {59881, 59367, 57825}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 8481, 9766}
+        set ANSI red color to {65535, 26214, 6682}
+        set ANSI green color to {62194, 59110, 43433}
+        set ANSI yellow color to {65535, 56540, 11565}
+        set ANSI blue color to {16448, 49087, 65535}
+        set ANSI magenta color to {44718, 38036, 63993}
+        set ANSI cyan color to {64507, 27242, 52171}
+        set ANSI white color to {61423, 61680, 63993}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 22359, 28270}
+        set ANSI bright red color to {65535, 26214, 6682}
+        set ANSI bright green color to {62194, 59110, 43433}
+        set ANSI bright yellow color to {65535, 56540, 11565}
+        set ANSI bright blue color to {16448, 49087, 65535}
+        set ANSI bright magenta color to {44718, 38036, 63993}
+        set ANSI bright cyan color to {64507, 27242, 52171}
+        set ANSI bright white color to {62194, 64507, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-github.sh
+++ b/scripts/base16-github.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {13107, 13107, 13107}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {60909, 27242, 17219}
+        set ANSI green color to {6168, 13878, 37265}
+        set ANSI yellow color to {31097, 23901, 41891}
+        set ANSI blue color to {31097, 23901, 41891}
+        set ANSI magenta color to {42919, 7453, 23901}
+        set ANSI cyan color to {6168, 13878, 37265}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {51400, 51400, 64250}
+        set ANSI bright red color to {60909, 27242, 17219}
+        set ANSI bright green color to {6168, 13878, 37265}
+        set ANSI bright yellow color to {31097, 23901, 41891}
+        set ANSI bright blue color to {31097, 23901, 41891}
+        set ANSI bright magenta color to {42919, 7453, 23901}
+        set ANSI bright cyan color to {6168, 13878, 37265}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-google-dark.sh
+++ b/scripts/base16-google-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7453, 7967, 8481}
+        set foreground color to {50629, 51400, 50886}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7453, 7967, 8481}
+        set ANSI red color to {52428, 13364, 11051}
+        set ANSI green color to {6425, 34952, 17476}
+        set ANSI yellow color to {64507, 43433, 8738}
+        set ANSI blue color to {14649, 29041, 60909}
+        set ANSI magenta color to {41891, 27242, 51143}
+        set ANSI cyan color to {14649, 29041, 60909}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14135, 15163, 16705}
+        set ANSI bright red color to {52428, 13364, 11051}
+        set ANSI bright green color to {6425, 34952, 17476}
+        set ANSI bright yellow color to {64507, 43433, 8738}
+        set ANSI bright blue color to {14649, 29041, 60909}
+        set ANSI bright magenta color to {41891, 27242, 51143}
+        set ANSI bright cyan color to {14649, 29041, 60909}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-google-light.sh
+++ b/scripts/base16-google-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {14135, 15163, 16705}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {52428, 13364, 11051}
+        set ANSI green color to {6425, 34952, 17476}
+        set ANSI yellow color to {64507, 43433, 8738}
+        set ANSI blue color to {14649, 29041, 60909}
+        set ANSI magenta color to {41891, 27242, 51143}
+        set ANSI cyan color to {14649, 29041, 60909}
+        set ANSI white color to {10280, 10794, 11822}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {50629, 51400, 50886}
+        set ANSI bright red color to {52428, 13364, 11051}
+        set ANSI bright green color to {6425, 34952, 17476}
+        set ANSI bright yellow color to {64507, 43433, 8738}
+        set ANSI bright blue color to {14649, 29041, 60909}
+        set ANSI bright magenta color to {41891, 27242, 51143}
+        set ANSI bright cyan color to {14649, 29041, 60909}
+        set ANSI bright white color to {7453, 7967, 8481}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gotham.sh
+++ b/scripts/base16-gotham.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3084, 4112, 5140}
+        set foreground color to {22873, 40092, 43947}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3084, 4112, 5140}
+        set ANSI red color to {49858, 12593, 10023}
+        set ANSI green color to {13107, 34181, 40606}
+        set ANSI yellow color to {60909, 46260, 17219}
+        set ANSI blue color to {6425, 21588, 26214}
+        set ANSI magenta color to {34952, 35980, 42662}
+        set ANSI cyan color to {10794, 43176, 35209}
+        set ANSI white color to {39321, 53713, 52942}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {2313, 7967, 11822}
+        set ANSI bright red color to {49858, 12593, 10023}
+        set ANSI bright green color to {13107, 34181, 40606}
+        set ANSI bright yellow color to {60909, 46260, 17219}
+        set ANSI bright blue color to {6425, 21588, 26214}
+        set ANSI bright magenta color to {34952, 35980, 42662}
+        set ANSI bright cyan color to {10794, 43176, 35209}
+        set ANSI bright white color to {54227, 60395, 59881}
+    end tell
+end tell
+EOF

--- a/scripts/base16-grayscale-dark.sh
+++ b/scripts/base16-grayscale-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 4112, 4112}
+        set foreground color to {47545, 47545, 47545}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 4112, 4112}
+        set ANSI red color to {31868, 31868, 31868}
+        set ANSI green color to {36494, 36494, 36494}
+        set ANSI yellow color to {41120, 41120, 41120}
+        set ANSI blue color to {26728, 26728, 26728}
+        set ANSI magenta color to {29812, 29812, 29812}
+        set ANSI cyan color to {34438, 34438, 34438}
+        set ANSI white color to {58339, 58339, 58339}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17990, 17990, 17990}
+        set ANSI bright red color to {31868, 31868, 31868}
+        set ANSI bright green color to {36494, 36494, 36494}
+        set ANSI bright yellow color to {41120, 41120, 41120}
+        set ANSI bright blue color to {26728, 26728, 26728}
+        set ANSI bright magenta color to {29812, 29812, 29812}
+        set ANSI bright cyan color to {34438, 34438, 34438}
+        set ANSI bright white color to {63479, 63479, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-grayscale-light.sh
+++ b/scripts/base16-grayscale-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63479, 63479, 63479}
+        set foreground color to {17990, 17990, 17990}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63479, 63479, 63479}
+        set ANSI red color to {31868, 31868, 31868}
+        set ANSI green color to {36494, 36494, 36494}
+        set ANSI yellow color to {41120, 41120, 41120}
+        set ANSI blue color to {26728, 26728, 26728}
+        set ANSI magenta color to {29812, 29812, 29812}
+        set ANSI cyan color to {34438, 34438, 34438}
+        set ANSI white color to {9509, 9509, 9509}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {47545, 47545, 47545}
+        set ANSI bright red color to {31868, 31868, 31868}
+        set ANSI bright green color to {36494, 36494, 36494}
+        set ANSI bright yellow color to {41120, 41120, 41120}
+        set ANSI bright blue color to {26728, 26728, 26728}
+        set ANSI bright magenta color to {29812, 29812, 29812}
+        set ANSI bright cyan color to {34438, 34438, 34438}
+        set ANSI bright white color to {4112, 4112, 4112}
+    end tell
+end tell
+EOF

--- a/scripts/base16-greenscreen.sh
+++ b/scripts/base16-greenscreen.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 4369, 0}
+        set foreground color to {0, 48059, 0}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 4369, 0}
+        set ANSI red color to {0, 30583, 0}
+        set ANSI green color to {0, 48059, 0}
+        set ANSI yellow color to {0, 30583, 0}
+        set ANSI blue color to {0, 39321, 0}
+        set ANSI magenta color to {0, 48059, 0}
+        set ANSI cyan color to {0, 21845, 0}
+        set ANSI white color to {0, 56797, 0}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 21845, 0}
+        set ANSI bright red color to {0, 30583, 0}
+        set ANSI bright green color to {0, 48059, 0}
+        set ANSI bright yellow color to {0, 30583, 0}
+        set ANSI bright blue color to {0, 39321, 0}
+        set ANSI bright magenta color to {0, 48059, 0}
+        set ANSI bright cyan color to {0, 21845, 0}
+        set ANSI bright white color to {0, 65535, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruber.sh
+++ b/scripts/base16-gruber.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 6168, 6168}
+        set foreground color to {62708, 62708, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 6168, 6168}
+        set ANSI red color to {62708, 14392, 16705}
+        set ANSI green color to {29555, 51657, 13878}
+        set ANSI yellow color to {65535, 56797, 13107}
+        set ANSI blue color to {38550, 42662, 51400}
+        set ANSI magenta color to {40606, 38293, 51143}
+        set ANSI cyan color to {38293, 43433, 40863}
+        set ANSI white color to {62965, 62965, 62965}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18504, 18504, 18504}
+        set ANSI bright red color to {62708, 14392, 16705}
+        set ANSI bright green color to {29555, 51657, 13878}
+        set ANSI bright yellow color to {65535, 56797, 13107}
+        set ANSI bright blue color to {38550, 42662, 51400}
+        set ANSI bright magenta color to {40606, 38293, 51143}
+        set ANSI bright cyan color to {38293, 43433, 40863}
+        set ANSI bright white color to {58596, 58596, 61423}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-dark-hard.sh
+++ b/scripts/base16-gruvbox-dark-hard.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7453, 8224, 8481}
+        set foreground color to {54741, 50372, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7453, 8224, 8481}
+        set ANSI red color to {64507, 18761, 13364}
+        set ANSI green color to {47288, 48059, 9766}
+        set ANSI yellow color to {64250, 48573, 12079}
+        set ANSI blue color to {33667, 42405, 39064}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {36494, 49344, 31868}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {64507, 18761, 13364}
+        set ANSI bright green color to {47288, 48059, 9766}
+        set ANSI bright yellow color to {64250, 48573, 12079}
+        set ANSI bright blue color to {33667, 42405, 39064}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {36494, 49344, 31868}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-dark-medium.sh
+++ b/scripts/base16-gruvbox-dark-medium.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 10280, 10280}
+        set foreground color to {54741, 50372, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 10280, 10280}
+        set ANSI red color to {64507, 18761, 13364}
+        set ANSI green color to {47288, 48059, 9766}
+        set ANSI yellow color to {64250, 48573, 12079}
+        set ANSI blue color to {33667, 42405, 39064}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {36494, 49344, 31868}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {64507, 18761, 13364}
+        set ANSI bright green color to {47288, 48059, 9766}
+        set ANSI bright yellow color to {64250, 48573, 12079}
+        set ANSI bright blue color to {33667, 42405, 39064}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {36494, 49344, 31868}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-dark-pale.sh
+++ b/scripts/base16-gruvbox-dark-pale.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 9766, 9766}
+        set foreground color to {56026, 47545, 38807}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 9766, 9766}
+        set ANSI red color to {55255, 24415, 24415}
+        set ANSI green color to {44975, 44975, 0}
+        set ANSI yellow color to {65535, 44975, 0}
+        set ANSI blue color to {33667, 44461, 44461}
+        set ANSI magenta color to {54484, 34181, 44461}
+        set ANSI cyan color to {34181, 44461, 34181}
+        set ANSI white color to {54741, 50372, 41377}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20046, 20046, 20046}
+        set ANSI bright red color to {55255, 24415, 24415}
+        set ANSI bright green color to {44975, 44975, 0}
+        set ANSI bright yellow color to {65535, 44975, 0}
+        set ANSI bright blue color to {33667, 44461, 44461}
+        set ANSI bright magenta color to {54484, 34181, 44461}
+        set ANSI bright cyan color to {34181, 44461, 34181}
+        set ANSI bright white color to {60395, 56283, 45746}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-dark-soft.sh
+++ b/scripts/base16-gruvbox-dark-soft.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {12850, 12336, 12079}
+        set foreground color to {54741, 50372, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {12850, 12336, 12079}
+        set ANSI red color to {64507, 18761, 13364}
+        set ANSI green color to {47288, 48059, 9766}
+        set ANSI yellow color to {64250, 48573, 12079}
+        set ANSI blue color to {33667, 42405, 39064}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {36494, 49344, 31868}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {64507, 18761, 13364}
+        set ANSI bright green color to {47288, 48059, 9766}
+        set ANSI bright yellow color to {64250, 48573, 12079}
+        set ANSI bright blue color to {33667, 42405, 39064}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {36494, 49344, 31868}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-light-hard.sh
+++ b/scripts/base16-gruvbox-light-hard.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63993, 62965, 55255}
+        set foreground color to {20560, 18761, 17733}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63993, 62965, 55255}
+        set ANSI red color to {40349, 0, 1542}
+        set ANSI green color to {31097, 29812, 3598}
+        set ANSI yellow color to {46517, 30326, 5140}
+        set ANSI blue color to {1799, 26214, 30840}
+        set ANSI magenta color to {36751, 16191, 29041}
+        set ANSI cyan color to {16962, 31611, 22616}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 50372, 41377}
+        set ANSI bright red color to {40349, 0, 1542}
+        set ANSI bright green color to {31097, 29812, 3598}
+        set ANSI bright yellow color to {46517, 30326, 5140}
+        set ANSI bright blue color to {1799, 26214, 30840}
+        set ANSI bright magenta color to {36751, 16191, 29041}
+        set ANSI bright cyan color to {16962, 31611, 22616}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-light-medium.sh
+++ b/scripts/base16-gruvbox-light-medium.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 61937, 51143}
+        set foreground color to {20560, 18761, 17733}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 61937, 51143}
+        set ANSI red color to {40349, 0, 1542}
+        set ANSI green color to {31097, 29812, 3598}
+        set ANSI yellow color to {46517, 30326, 5140}
+        set ANSI blue color to {1799, 26214, 30840}
+        set ANSI magenta color to {36751, 16191, 29041}
+        set ANSI cyan color to {16962, 31611, 22616}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 50372, 41377}
+        set ANSI bright red color to {40349, 0, 1542}
+        set ANSI bright green color to {31097, 29812, 3598}
+        set ANSI bright yellow color to {46517, 30326, 5140}
+        set ANSI bright blue color to {1799, 26214, 30840}
+        set ANSI bright magenta color to {36751, 16191, 29041}
+        set ANSI bright cyan color to {16962, 31611, 22616}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-light-soft.sh
+++ b/scripts/base16-gruvbox-light-soft.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62194, 58853, 48316}
+        set foreground color to {20560, 18761, 17733}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62194, 58853, 48316}
+        set ANSI red color to {40349, 0, 1542}
+        set ANSI green color to {31097, 29812, 3598}
+        set ANSI yellow color to {46517, 30326, 5140}
+        set ANSI blue color to {1799, 26214, 30840}
+        set ANSI magenta color to {36751, 16191, 29041}
+        set ANSI cyan color to {16962, 31611, 22616}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 50372, 41377}
+        set ANSI bright red color to {40349, 0, 1542}
+        set ANSI bright green color to {31097, 29812, 3598}
+        set ANSI bright yellow color to {46517, 30326, 5140}
+        set ANSI bright blue color to {1799, 26214, 30840}
+        set ANSI bright magenta color to {36751, 16191, 29041}
+        set ANSI bright cyan color to {16962, 31611, 22616}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-dark-hard.sh
+++ b/scripts/base16-gruvbox-material-dark-hard.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 8224, 8224}
+        set foreground color to {56797, 51143, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 8224, 8224}
+        set ANSI red color to {60138, 26985, 25186}
+        set ANSI green color to {43433, 46774, 25957}
+        set ANSI yellow color to {55512, 42662, 22359}
+        set ANSI blue color to {32125, 44718, 41891}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {35209, 46260, 33410}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {60138, 26985, 25186}
+        set ANSI bright green color to {43433, 46774, 25957}
+        set ANSI bright yellow color to {55512, 42662, 22359}
+        set ANSI bright blue color to {32125, 44718, 41891}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {35209, 46260, 33410}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-dark-medium.sh
+++ b/scripts/base16-gruvbox-material-dark-medium.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 10280, 10280}
+        set foreground color to {56797, 51143, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 10280, 10280}
+        set ANSI red color to {60138, 26985, 25186}
+        set ANSI green color to {43433, 46774, 25957}
+        set ANSI yellow color to {55512, 42662, 22359}
+        set ANSI blue color to {32125, 44718, 41891}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {35209, 46260, 33410}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20560, 18761, 17733}
+        set ANSI bright red color to {60138, 26985, 25186}
+        set ANSI bright green color to {43433, 46774, 25957}
+        set ANSI bright yellow color to {55512, 42662, 22359}
+        set ANSI bright blue color to {32125, 44718, 41891}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {35209, 46260, 33410}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-dark-soft.sh
+++ b/scripts/base16-gruvbox-material-dark-soft.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {12850, 12336, 12079}
+        set foreground color to {56797, 51143, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {12850, 12336, 12079}
+        set ANSI red color to {60138, 26985, 25186}
+        set ANSI green color to {43433, 46774, 25957}
+        set ANSI yellow color to {55512, 42662, 22359}
+        set ANSI blue color to {32125, 44718, 41891}
+        set ANSI magenta color to {54227, 34438, 39835}
+        set ANSI cyan color to {35209, 46260, 33410}
+        set ANSI white color to {60395, 56283, 45746}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 21074, 19532}
+        set ANSI bright red color to {60138, 26985, 25186}
+        set ANSI bright green color to {43433, 46774, 25957}
+        set ANSI bright yellow color to {55512, 42662, 22359}
+        set ANSI bright blue color to {32125, 44718, 41891}
+        set ANSI bright magenta color to {54227, 34438, 39835}
+        set ANSI bright cyan color to {35209, 46260, 33410}
+        set ANSI bright white color to {64507, 61937, 51143}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-light-hard.sh
+++ b/scripts/base16-gruvbox-material-light-hard.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63993, 62965, 55255}
+        set foreground color to {25957, 18247, 13621}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63993, 62965, 55255}
+        set ANSI red color to {49601, 19018, 19018}
+        set ANSI green color to {27756, 30840, 11822}
+        set ANSI yellow color to {46260, 29041, 2313}
+        set ANSI blue color to {17733, 28784, 31354}
+        set ANSI magenta color to {38036, 24158, 32896}
+        set ANSI cyan color to {19532, 31354, 23901}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57568, 53199, 43433}
+        set ANSI bright red color to {49601, 19018, 19018}
+        set ANSI bright green color to {27756, 30840, 11822}
+        set ANSI bright yellow color to {46260, 29041, 2313}
+        set ANSI bright blue color to {17733, 28784, 31354}
+        set ANSI bright magenta color to {38036, 24158, 32896}
+        set ANSI bright cyan color to {19532, 31354, 23901}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-light-medium.sh
+++ b/scripts/base16-gruvbox-material-light-medium.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 61937, 51143}
+        set foreground color to {25957, 18247, 13621}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 61937, 51143}
+        set ANSI red color to {49601, 19018, 19018}
+        set ANSI green color to {27756, 30840, 11822}
+        set ANSI yellow color to {46260, 29041, 2313}
+        set ANSI blue color to {17733, 28784, 31354}
+        set ANSI magenta color to {38036, 24158, 32896}
+        set ANSI cyan color to {19532, 31354, 23901}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 50372, 41377}
+        set ANSI bright red color to {49601, 19018, 19018}
+        set ANSI bright green color to {27756, 30840, 11822}
+        set ANSI bright yellow color to {46260, 29041, 2313}
+        set ANSI bright blue color to {17733, 28784, 31354}
+        set ANSI bright magenta color to {38036, 24158, 32896}
+        set ANSI bright cyan color to {19532, 31354, 23901}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-gruvbox-material-light-soft.sh
+++ b/scripts/base16-gruvbox-material-light-soft.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62194, 58853, 48316}
+        set foreground color to {25957, 18247, 13621}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62194, 58853, 48316}
+        set ANSI red color to {49601, 19018, 19018}
+        set ANSI green color to {27756, 30840, 11822}
+        set ANSI yellow color to {46260, 29041, 2313}
+        set ANSI blue color to {17733, 28784, 31354}
+        set ANSI magenta color to {38036, 24158, 32896}
+        set ANSI cyan color to {19532, 31354, 23901}
+        set ANSI white color to {15420, 14392, 13878}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {51657, 47545, 39578}
+        set ANSI bright red color to {49601, 19018, 19018}
+        set ANSI bright green color to {27756, 30840, 11822}
+        set ANSI bright yellow color to {46260, 29041, 2313}
+        set ANSI bright blue color to {17733, 28784, 31354}
+        set ANSI bright magenta color to {38036, 24158, 32896}
+        set ANSI bright cyan color to {19532, 31354, 23901}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-hardcore.sh
+++ b/scripts/base16-hardcore.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8481, 8481, 8481}
+        set foreground color to {52685, 52685, 52685}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8481, 8481, 8481}
+        set ANSI red color to {63993, 9766, 29298}
+        set ANSI green color to {42662, 58082, 11822}
+        set ANSI yellow color to {59110, 56283, 29812}
+        set ANSI blue color to {26214, 55769, 61423}
+        set ANSI magenta color to {40606, 28527, 65278}
+        set ANSI cyan color to {28784, 33667, 34695}
+        set ANSI white color to {58853, 58853, 58853}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13621, 13621, 13621}
+        set ANSI bright red color to {63993, 9766, 29298}
+        set ANSI bright green color to {42662, 58082, 11822}
+        set ANSI bright yellow color to {59110, 56283, 29812}
+        set ANSI bright blue color to {26214, 55769, 61423}
+        set ANSI bright magenta color to {40606, 28527, 65278}
+        set ANSI bright cyan color to {28784, 33667, 34695}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-harmonic16-dark.sh
+++ b/scripts/base16-harmonic16-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {2827, 7196, 11308}
+        set foreground color to {52171, 54998, 58082}
+
+        -- Set ANSI Colors
+        set ANSI black color to {2827, 7196, 11308}
+        set ANSI red color to {49087, 35723, 22102}
+        set ANSI green color to {22102, 49087, 35723}
+        set ANSI yellow color to {35723, 49087, 22102}
+        set ANSI blue color to {35723, 22102, 49087}
+        set ANSI magenta color to {49087, 22102, 35723}
+        set ANSI cyan color to {22102, 35723, 49087}
+        set ANSI white color to {58853, 60395, 61937}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16448, 23644, 31097}
+        set ANSI bright red color to {49087, 35723, 22102}
+        set ANSI bright green color to {22102, 49087, 35723}
+        set ANSI bright yellow color to {35723, 49087, 22102}
+        set ANSI bright blue color to {35723, 22102, 49087}
+        set ANSI bright magenta color to {49087, 22102, 35723}
+        set ANSI bright cyan color to {22102, 35723, 49087}
+        set ANSI bright white color to {63479, 63993, 64507}
+    end tell
+end tell
+EOF

--- a/scripts/base16-harmonic16-light.sh
+++ b/scripts/base16-harmonic16-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63479, 63993, 64507}
+        set foreground color to {16448, 23644, 31097}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63479, 63993, 64507}
+        set ANSI red color to {49087, 35723, 22102}
+        set ANSI green color to {22102, 49087, 35723}
+        set ANSI yellow color to {35723, 49087, 22102}
+        set ANSI blue color to {35723, 22102, 49087}
+        set ANSI magenta color to {49087, 22102, 35723}
+        set ANSI cyan color to {22102, 35723, 49087}
+        set ANSI white color to {8738, 15163, 21588}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {52171, 54998, 58082}
+        set ANSI bright red color to {49087, 35723, 22102}
+        set ANSI bright green color to {22102, 49087, 35723}
+        set ANSI bright yellow color to {35723, 49087, 22102}
+        set ANSI bright blue color to {35723, 22102, 49087}
+        set ANSI bright magenta color to {49087, 22102, 35723}
+        set ANSI bright cyan color to {22102, 35723, 49087}
+        set ANSI bright white color to {2827, 7196, 11308}
+    end tell
+end tell
+EOF

--- a/scripts/base16-heetch-light.sh
+++ b/scripts/base16-heetch-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65278, 65535, 65535}
+        set foreground color to {23130, 18761, 28270}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65278, 65535, 65535}
+        set ANSI red color to {10023, 55769, 54741}
+        set ANSI green color to {63736, 0, 22873}
+        set ANSI yellow color to {23387, 41634, 46774}
+        set ANSI blue color to {18247, 63993, 62965}
+        set ANSI magenta color to {48573, 257, 21074}
+        set ANSI cyan color to {50115, 13878, 30840}
+        set ANSI white color to {18247, 1285, 17990}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {31611, 28013, 35723}
+        set ANSI bright red color to {10023, 55769, 54741}
+        set ANSI bright green color to {63736, 0, 22873}
+        set ANSI bright yellow color to {23387, 41634, 46774}
+        set ANSI bright blue color to {18247, 63993, 62965}
+        set ANSI bright magenta color to {48573, 257, 21074}
+        set ANSI bright cyan color to {50115, 13878, 30840}
+        set ANSI bright white color to {6425, 257, 13364}
+    end tell
+end tell
+EOF

--- a/scripts/base16-heetch.sh
+++ b/scripts/base16-heetch.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6425, 257, 13364}
+        set foreground color to {48573, 46774, 50629}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6425, 257, 13364}
+        set ANSI red color to {10023, 55769, 54741}
+        set ANSI green color to {50115, 13878, 30840}
+        set ANSI yellow color to {36751, 27756, 38807}
+        set ANSI blue color to {48573, 257, 21074}
+        set ANSI magenta color to {33410, 771, 19532}
+        set ANSI cyan color to {63736, 0, 22873}
+        set ANSI white color to {57054, 56026, 58082}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 18761, 28270}
+        set ANSI bright red color to {10023, 55769, 54741}
+        set ANSI bright green color to {50115, 13878, 30840}
+        set ANSI bright yellow color to {36751, 27756, 38807}
+        set ANSI bright blue color to {48573, 257, 21074}
+        set ANSI bright magenta color to {33410, 771, 19532}
+        set ANSI bright cyan color to {63736, 0, 22873}
+        set ANSI bright white color to {65278, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-helios.sh
+++ b/scripts/base16-helios.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7453, 8224, 8481}
+        set foreground color to {54741, 54741, 54741}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7453, 8224, 8481}
+        set ANSI red color to {55255, 9766, 14392}
+        set ANSI green color to {34952, 47545, 11565}
+        set ANSI yellow color to {61937, 40349, 6682}
+        set ANSI blue color to {7710, 35723, 44204}
+        set ANSI magenta color to {48830, 16962, 25700}
+        set ANSI cyan color to {6939, 42405, 38293}
+        set ANSI white color to {56797, 56797, 56797}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21331, 22616, 23387}
+        set ANSI bright red color to {55255, 9766, 14392}
+        set ANSI bright green color to {34952, 47545, 11565}
+        set ANSI bright yellow color to {61937, 40349, 6682}
+        set ANSI bright blue color to {7710, 35723, 44204}
+        set ANSI bright magenta color to {48830, 16962, 25700}
+        set ANSI bright cyan color to {6939, 42405, 38293}
+        set ANSI bright white color to {58853, 58853, 58853}
+    end tell
+end tell
+EOF

--- a/scripts/base16-hopscotch.sh
+++ b/scripts/base16-hopscotch.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {12850, 10537, 12593}
+        set foreground color to {47545, 46517, 47288}
+
+        -- Set ANSI Colors
+        set ANSI black color to {12850, 10537, 12593}
+        set ANSI red color to {56797, 17990, 19532}
+        set ANSI green color to {36751, 49601, 15934}
+        set ANSI yellow color to {65021, 52428, 22873}
+        set ANSI blue color to {4626, 37008, 49087}
+        set ANSI magenta color to {51400, 24158, 31868}
+        set ANSI cyan color to {5140, 39835, 37779}
+        set ANSI white color to {54741, 54227, 54741}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23644, 21588, 23387}
+        set ANSI bright red color to {56797, 17990, 19532}
+        set ANSI bright green color to {36751, 49601, 15934}
+        set ANSI bright yellow color to {65021, 52428, 22873}
+        set ANSI bright blue color to {4626, 37008, 49087}
+        set ANSI bright magenta color to {51400, 24158, 31868}
+        set ANSI bright cyan color to {5140, 39835, 37779}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-horizon-dark.sh
+++ b/scripts/base16-horizon-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 7710, 9766}
+        set foreground color to {52171, 52942, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 7710, 9766}
+        set ANSI red color to {59881, 15420, 22616}
+        set ANSI green color to {61423, 44975, 36494}
+        set ANSI yellow color to {61423, 47545, 37779}
+        set ANSI blue color to {57311, 21074, 29555}
+        set ANSI magenta color to {45232, 29298, 53713}
+        set ANSI cyan color to {9252, 43176, 46260}
+        set ANSI white color to {56540, 57311, 58596}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11822, 12336, 15934}
+        set ANSI bright red color to {59881, 15420, 22616}
+        set ANSI bright green color to {61423, 44975, 36494}
+        set ANSI bright yellow color to {61423, 47545, 37779}
+        set ANSI bright blue color to {57311, 21074, 29555}
+        set ANSI bright magenta color to {45232, 29298, 53713}
+        set ANSI bright cyan color to {9252, 43176, 46260}
+        set ANSI bright white color to {58339, 59110, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-horizon-light.sh
+++ b/scripts/base16-horizon-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65021, 61680, 60909}
+        set foreground color to {16448, 15420, 15677}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65021, 61680, 60909}
+        set ANSI red color to {63479, 37779, 39835}
+        set ANSI green color to {38036, 57825, 45232}
+        set ANSI yellow color to {64507, 57568, 55769}
+        set ANSI blue color to {56026, 4112, 16191}
+        set ANSI magenta color to {7453, 35209, 37265}
+        set ANSI cyan color to {56540, 13107, 6168}
+        set ANSI white color to {12336, 11308, 11565}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {63993, 52171, 48830}
+        set ANSI bright red color to {63479, 37779, 39835}
+        set ANSI bright green color to {38036, 57825, 45232}
+        set ANSI bright yellow color to {64507, 57568, 55769}
+        set ANSI bright blue color to {56026, 4112, 16191}
+        set ANSI bright magenta color to {7453, 35209, 37265}
+        set ANSI bright cyan color to {56540, 13107, 6168}
+        set ANSI bright white color to {8224, 7196, 7453}
+    end tell
+end tell
+EOF

--- a/scripts/base16-horizon-terminal-dark.sh
+++ b/scripts/base16-horizon-terminal-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 7710, 9766}
+        set foreground color to {52171, 52942, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 7710, 9766}
+        set ANSI red color to {59881, 22102, 30840}
+        set ANSI green color to {10537, 54227, 39064}
+        set ANSI yellow color to {64250, 49858, 39578}
+        set ANSI blue color to {9766, 48059, 55769}
+        set ANSI magenta color to {61166, 25700, 44204}
+        set ANSI cyan color to {22873, 57825, 58339}
+        set ANSI white color to {56540, 57311, 58596}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11822, 12336, 15934}
+        set ANSI bright red color to {59881, 22102, 30840}
+        set ANSI bright green color to {10537, 54227, 39064}
+        set ANSI bright yellow color to {64250, 49858, 39578}
+        set ANSI bright blue color to {9766, 48059, 55769}
+        set ANSI bright magenta color to {61166, 25700, 44204}
+        set ANSI bright cyan color to {22873, 57825, 58339}
+        set ANSI bright white color to {58339, 59110, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-horizon-terminal-light.sh
+++ b/scripts/base16-horizon-terminal-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65021, 61680, 60909}
+        set foreground color to {16448, 15420, 15677}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65021, 61680, 60909}
+        set ANSI red color to {59881, 22102, 30840}
+        set ANSI green color to {10537, 54227, 39064}
+        set ANSI yellow color to {64250, 56026, 53713}
+        set ANSI blue color to {9766, 48059, 55769}
+        set ANSI magenta color to {61166, 25700, 44204}
+        set ANSI cyan color to {22873, 57825, 58339}
+        set ANSI white color to {12336, 11308, 11565}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {63993, 52171, 48830}
+        set ANSI bright red color to {59881, 22102, 30840}
+        set ANSI bright green color to {10537, 54227, 39064}
+        set ANSI bright yellow color to {64250, 56026, 53713}
+        set ANSI bright blue color to {9766, 48059, 55769}
+        set ANSI bright magenta color to {61166, 25700, 44204}
+        set ANSI bright cyan color to {22873, 57825, 58339}
+        set ANSI bright white color to {8224, 7196, 7453}
+    end tell
+end tell
+EOF

--- a/scripts/base16-humanoid-dark.sh
+++ b/scripts/base16-humanoid-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 9766, 10537}
+        set foreground color to {63736, 63736, 62194}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 9766, 10537}
+        set ANSI red color to {61937, 4626, 13621}
+        set ANSI green color to {514, 55512, 18761}
+        set ANSI yellow color to {65535, 46774, 10023}
+        set ANSI blue color to {0, 42662, 64507}
+        set ANSI magenta color to {61937, 24158, 58339}
+        set ANSI cyan color to {3341, 55769, 54998}
+        set ANSI white color to {64764, 64764, 63222}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18504, 20046, 21588}
+        set ANSI bright red color to {61937, 4626, 13621}
+        set ANSI bright green color to {514, 55512, 18761}
+        set ANSI bright yellow color to {65535, 46774, 10023}
+        set ANSI bright blue color to {0, 42662, 64507}
+        set ANSI bright magenta color to {61937, 24158, 58339}
+        set ANSI bright cyan color to {3341, 55769, 54998}
+        set ANSI bright white color to {64764, 64764, 64764}
+    end tell
+end tell
+EOF

--- a/scripts/base16-humanoid-light.sh
+++ b/scripts/base16-humanoid-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63736, 63736, 62194}
+        set foreground color to {8995, 9766, 10537}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63736, 63736, 62194}
+        set ANSI red color to {45232, 5397, 6682}
+        set ANSI green color to {14392, 36494, 15420}
+        set ANSI yellow color to {65535, 46774, 10023}
+        set ANSI blue color to {0, 33410, 51657}
+        set ANSI magenta color to {28784, 3855, 39064}
+        set ANSI cyan color to {0, 36494, 36494}
+        set ANSI white color to {12079, 13107, 14135}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57054, 57054, 55512}
+        set ANSI bright red color to {45232, 5397, 6682}
+        set ANSI bright green color to {14392, 36494, 15420}
+        set ANSI bright yellow color to {65535, 46774, 10023}
+        set ANSI bright blue color to {0, 33410, 51657}
+        set ANSI bright magenta color to {28784, 3855, 39064}
+        set ANSI bright cyan color to {0, 36494, 36494}
+        set ANSI bright white color to {1799, 1799, 2056}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ia-dark.sh
+++ b/scripts/base16-ia-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6682, 6682, 6682}
+        set foreground color to {52428, 52428, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6682, 6682, 6682}
+        set ANSI red color to {55512, 34181, 26728}
+        set ANSI green color to {33667, 42148, 29041}
+        set ANSI yellow color to {47545, 37779, 21331}
+        set ANSI blue color to {36494, 52428, 56797}
+        set ANSI magenta color to {47545, 36494, 45746}
+        set ANSI cyan color to {31868, 40092, 44718}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {7453, 16705, 19789}
+        set ANSI bright red color to {55512, 34181, 26728}
+        set ANSI bright green color to {33667, 42148, 29041}
+        set ANSI bright yellow color to {47545, 37779, 21331}
+        set ANSI bright blue color to {36494, 52428, 56797}
+        set ANSI bright magenta color to {47545, 36494, 45746}
+        set ANSI bright cyan color to {31868, 40092, 44718}
+        set ANSI bright white color to {63736, 63736, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ia-light.sh
+++ b/scripts/base16-ia-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63222, 63222, 63222}
+        set foreground color to {6168, 6168, 6168}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63222, 63222, 63222}
+        set ANSI red color to {40092, 23130, 514}
+        set ANSI green color to {14392, 30840, 7196}
+        set ANSI yellow color to {50372, 33410, 6168}
+        set ANSI blue color to {18504, 47802, 49858}
+        set ANSI magenta color to {43433, 17733, 39064}
+        set ANSI cyan color to {11565, 27499, 45489}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {48573, 58853, 62194}
+        set ANSI bright red color to {40092, 23130, 514}
+        set ANSI bright green color to {14392, 30840, 7196}
+        set ANSI bright yellow color to {50372, 33410, 6168}
+        set ANSI bright blue color to {18504, 47802, 49858}
+        set ANSI bright magenta color to {43433, 17733, 39064}
+        set ANSI bright cyan color to {11565, 27499, 45489}
+        set ANSI bright white color to {63736, 63736, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-icy.sh
+++ b/scripts/base16-icy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {514, 4112, 4626}
+        set foreground color to {2313, 23387, 26471}
+
+        -- Set ANSI Colors
+        set ANSI black color to {514, 4112, 4626}
+        set ANSI red color to {5654, 49601, 55769}
+        set ANSI green color to {19789, 53456, 57825}
+        set ANSI yellow color to {32896, 57054, 60138}
+        set ANSI blue color to {0, 48316, 54484}
+        set ANSI magenta color to {0, 44204, 49601}
+        set ANSI cyan color to {9766, 50886, 56026}
+        set ANSI white color to {3084, 31868, 35980}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {1028, 7967, 8995}
+        set ANSI bright red color to {5654, 49601, 55769}
+        set ANSI bright green color to {19789, 53456, 57825}
+        set ANSI bright yellow color to {32896, 57054, 60138}
+        set ANSI bright blue color to {0, 48316, 54484}
+        set ANSI bright magenta color to {0, 44204, 49601}
+        set ANSI bright cyan color to {9766, 50886, 56026}
+        set ANSI bright white color to {4112, 40092, 45232}
+    end tell
+end tell
+EOF

--- a/scripts/base16-irblack.sh
+++ b/scripts/base16-irblack.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {46517, 46003, 43690}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {65535, 27756, 24672}
+        set ANSI green color to {43176, 65535, 24672}
+        set ANSI yellow color to {65535, 65535, 46774}
+        set ANSI blue color to {38550, 52171, 65278}
+        set ANSI magenta color to {65535, 29555, 65021}
+        set ANSI cyan color to {50886, 50629, 65278}
+        set ANSI white color to {55769, 55255, 52428}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18504, 18504, 17476}
+        set ANSI bright red color to {65535, 27756, 24672}
+        set ANSI bright green color to {43176, 65535, 24672}
+        set ANSI bright yellow color to {65535, 65535, 46774}
+        set ANSI bright blue color to {38550, 52171, 65278}
+        set ANSI bright magenta color to {65535, 29555, 65021}
+        set ANSI bright cyan color to {50886, 50629, 65278}
+        set ANSI bright white color to {65021, 64507, 61166}
+    end tell
+end tell
+EOF

--- a/scripts/base16-isotope.sh
+++ b/scripts/base16-isotope.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {65535, 0, 0}
+        set ANSI green color to {13107, 65535, 0}
+        set ANSI yellow color to {65535, 0, 39321}
+        set ANSI blue color to {0, 26214, 65535}
+        set ANSI magenta color to {52428, 0, 65535}
+        set ANSI cyan color to {0, 65535, 65535}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24672, 24672, 24672}
+        set ANSI bright red color to {65535, 0, 0}
+        set ANSI bright green color to {13107, 65535, 0}
+        set ANSI bright yellow color to {65535, 0, 39321}
+        set ANSI bright blue color to {0, 26214, 65535}
+        set ANSI bright magenta color to {52428, 0, 65535}
+        set ANSI bright cyan color to {0, 65535, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-jabuti.sh
+++ b/scripts/base16-jabuti.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 10794, 14135}
+        set foreground color to {49344, 52171, 58339}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 10794, 14135}
+        set ANSI red color to {60652, 27242, 34952}
+        set ANSI green color to {16191, 56026, 42148}
+        set ANSI yellow color to {57825, 50886, 38807}
+        set ANSI blue color to {16191, 50886, 57054}
+        set ANSI magenta color to {48830, 38293, 65535}
+        set ANSI cyan color to {65535, 32382, 46774}
+        set ANSI white color to {55769, 57568, 61166}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15420, 15934, 20817}
+        set ANSI bright red color to {60652, 27242, 34952}
+        set ANSI bright green color to {16191, 56026, 42148}
+        set ANSI bright yellow color to {57825, 50886, 38807}
+        set ANSI bright blue color to {16191, 50886, 57054}
+        set ANSI bright magenta color to {48830, 38293, 65535}
+        set ANSI bright cyan color to {65535, 32382, 46774}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-kanagawa.sh
+++ b/scripts/base16-kanagawa.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7967, 7967, 10280}
+        set foreground color to {56540, 55255, 47802}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7967, 7967, 10280}
+        set ANSI red color to {50115, 16448, 17219}
+        set ANSI green color to {30326, 38036, 27242}
+        set ANSI yellow color to {49344, 41891, 28270}
+        set ANSI blue color to {32382, 40092, 55512}
+        set ANSI magenta color to {38293, 32639, 47288}
+        set ANSI cyan color to {27242, 38293, 35209}
+        set ANSI white color to {51400, 49344, 37779}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 12850, 18761}
+        set ANSI bright red color to {50115, 16448, 17219}
+        set ANSI bright green color to {30326, 38036, 27242}
+        set ANSI bright yellow color to {49344, 41891, 28270}
+        set ANSI bright blue color to {32382, 40092, 55512}
+        set ANSI bright magenta color to {38293, 32639, 47288}
+        set ANSI bright cyan color to {27242, 38293, 35209}
+        set ANSI bright white color to {29041, 31868, 31868}
+    end tell
+end tell
+EOF

--- a/scripts/base16-katy.sh
+++ b/scripts/base16-katy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 11565, 15934}
+        set foreground color to {38293, 40349, 52171}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 11565, 15934}
+        set ANSI red color to {28270, 39064, 57825}
+        set ANSI green color to {30840, 49344, 28270}
+        set ANSI yellow color to {57568, 42405, 22359}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {51143, 37522, 60138}
+        set ANSI cyan color to {33667, 47031, 58853}
+        set ANSI white color to {38293, 40349, 52171}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23644, 22873, 35723}
+        set ANSI bright red color to {28270, 39064, 57825}
+        set ANSI bright green color to {30840, 49344, 28270}
+        set ANSI bright yellow color to {57568, 42405, 22359}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {51143, 37522, 60138}
+        set ANSI bright cyan color to {33667, 47031, 58853}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-kimber.sh
+++ b/scripts/base16-kimber.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 8738, 8738}
+        set foreground color to {57054, 57054, 59367}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 8738, 8738}
+        set ANSI red color to {51400, 35980, 35980}
+        set ANSI green color to {39321, 51400, 39321}
+        set ANSI yellow color to {55512, 46517, 28013}
+        set ANSI blue color to {21331, 31868, 40092}
+        set ANSI magenta color to {34438, 51914, 52685}
+        set ANSI cyan color to {30840, 46260, 46260}
+        set ANSI white color to {50115, 50115, 46260}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21845, 23901, 21845}
+        set ANSI bright red color to {51400, 35980, 35980}
+        set ANSI bright green color to {39321, 51400, 39321}
+        set ANSI bright yellow color to {55512, 46517, 28013}
+        set ANSI bright blue color to {21331, 31868, 40092}
+        set ANSI bright magenta color to {34438, 51914, 52685}
+        set ANSI bright cyan color to {30840, 46260, 46260}
+        set ANSI bright white color to {65535, 65535, 59110}
+    end tell
+end tell
+EOF

--- a/scripts/base16-lime.sh
+++ b/scripts/base16-lime.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6682, 6682, 12079}
+        set foreground color to {33153, 33153, 30069}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6682, 6682, 12079}
+        set ANSI red color to {65535, 26214, 10794}
+        set ANSI green color to {35980, 55769, 31868}
+        set ANSI yellow color to {65535, 53713, 24158}
+        set ANSI blue color to {11051, 37522, 28527}
+        set ANSI magenta color to {6939, 33410, 24415}
+        set ANSI cyan color to {19532, 44461, 33667}
+        set ANSI white color to {65535, 62194, 53713}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10794, 10794, 16191}
+        set ANSI bright red color to {65535, 26214, 10794}
+        set ANSI bright green color to {35980, 55769, 31868}
+        set ANSI bright yellow color to {65535, 53713, 24158}
+        set ANSI bright blue color to {11051, 37522, 28527}
+        set ANSI bright magenta color to {6939, 33410, 24415}
+        set ANSI bright cyan color to {19532, 44461, 33667}
+        set ANSI bright white color to {65535, 63736, 57825}
+    end tell
+end tell
+EOF

--- a/scripts/base16-macintosh.sh
+++ b/scripts/base16-macintosh.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49344, 49344, 49344}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {56797, 2313, 1799}
+        set ANSI green color to {7967, 47031, 5140}
+        set ANSI yellow color to {64507, 62451, 1285}
+        set ANSI blue color to {0, 0, 54227}
+        set ANSI magenta color to {18247, 0, 42405}
+        set ANSI cyan color to {514, 43947, 60138}
+        set ANSI white color to {49344, 49344, 49344}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16448, 16448, 16448}
+        set ANSI bright red color to {56797, 2313, 1799}
+        set ANSI bright green color to {7967, 47031, 5140}
+        set ANSI bright yellow color to {64507, 62451, 1285}
+        set ANSI bright blue color to {0, 0, 54227}
+        set ANSI bright magenta color to {18247, 0, 42405}
+        set ANSI bright cyan color to {514, 43947, 60138}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-marrakesh.sh
+++ b/scripts/base16-marrakesh.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 5654, 514}
+        set foreground color to {38036, 36494, 18504}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 5654, 514}
+        set ANSI red color to {50115, 21331, 22873}
+        set ANSI green color to {6168, 38807, 20046}
+        set ANSI yellow color to {43176, 33667, 14649}
+        set ANSI blue color to {18247, 31868, 41377}
+        set ANSI magenta color to {34952, 26728, 46003}
+        set ANSI cyan color to {30069, 42919, 14392}
+        set ANSI white color to {52428, 50115, 31354}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24415, 23387, 5911}
+        set ANSI bright red color to {50115, 21331, 22873}
+        set ANSI bright green color to {6168, 38807, 20046}
+        set ANSI bright yellow color to {43176, 33667, 14649}
+        set ANSI bright blue color to {18247, 31868, 41377}
+        set ANSI bright magenta color to {34952, 26728, 46003}
+        set ANSI bright cyan color to {30069, 42919, 14392}
+        set ANSI bright white color to {64250, 61680, 42405}
+    end tell
+end tell
+EOF

--- a/scripts/base16-materia.sh
+++ b/scripts/base16-materia.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 12850, 14392}
+        set foreground color to {52685, 54227, 57054}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 12850, 14392}
+        set ANSI red color to {60652, 24415, 26471}
+        set ANSI green color to {35723, 54998, 18761}
+        set ANSI yellow color to {65535, 52428, 0}
+        set ANSI blue color to {35209, 56797, 65535}
+        set ANSI magenta color to {33410, 43690, 65535}
+        set ANSI cyan color to {32896, 52171, 50372}
+        set ANSI white color to {54741, 56283, 58853}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14135, 18247, 20303}
+        set ANSI bright red color to {60652, 24415, 26471}
+        set ANSI bright green color to {35723, 54998, 18761}
+        set ANSI bright yellow color to {65535, 52428, 0}
+        set ANSI bright blue color to {35209, 56797, 65535}
+        set ANSI bright magenta color to {33410, 43690, 65535}
+        set ANSI bright cyan color to {32896, 52171, 50372}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-material-darker.sh
+++ b/scripts/base16-material-darker.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8481, 8481, 8481}
+        set foreground color to {61166, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8481, 8481, 8481}
+        set ANSI red color to {61680, 29041, 30840}
+        set ANSI green color to {50115, 59624, 36237}
+        set ANSI yellow color to {65535, 52171, 27499}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {51143, 37522, 60138}
+        set ANSI cyan color to {35209, 56797, 65535}
+        set ANSI white color to {61166, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13621, 13621, 13621}
+        set ANSI bright red color to {61680, 29041, 30840}
+        set ANSI bright green color to {50115, 59624, 36237}
+        set ANSI bright yellow color to {65535, 52171, 27499}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {51143, 37522, 60138}
+        set ANSI bright cyan color to {35209, 56797, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-material-lighter.sh
+++ b/scripts/base16-material-lighter.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 64250, 64250}
+        set foreground color to {32896, 52171, 50372}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 64250, 64250}
+        set ANSI red color to {65535, 21331, 28784}
+        set ANSI green color to {37265, 47288, 22873}
+        set ANSI yellow color to {65535, 46774, 11308}
+        set ANSI blue color to {24929, 33410, 47288}
+        set ANSI magenta color to {31868, 19789, 65535}
+        set ANSI cyan color to {14649, 44461, 46517}
+        set ANSI white color to {32896, 52171, 50372}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {52428, 60138, 59367}
+        set ANSI bright red color to {65535, 21331, 28784}
+        set ANSI bright green color to {37265, 47288, 22873}
+        set ANSI bright yellow color to {65535, 46774, 11308}
+        set ANSI bright blue color to {24929, 33410, 47288}
+        set ANSI bright magenta color to {31868, 19789, 65535}
+        set ANSI bright cyan color to {14649, 44461, 46517}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-material-palenight.sh
+++ b/scripts/base16-material-palenight.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 11565, 15934}
+        set foreground color to {38293, 40349, 52171}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 11565, 15934}
+        set ANSI red color to {61680, 29041, 30840}
+        set ANSI green color to {50115, 59624, 36237}
+        set ANSI yellow color to {65535, 52171, 27499}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {51143, 37522, 60138}
+        set ANSI cyan color to {35209, 56797, 65535}
+        set ANSI white color to {38293, 40349, 52171}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12850, 14135, 19789}
+        set ANSI bright red color to {61680, 29041, 30840}
+        set ANSI bright green color to {50115, 59624, 36237}
+        set ANSI bright yellow color to {65535, 52171, 27499}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {51143, 37522, 60138}
+        set ANSI bright cyan color to {35209, 56797, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-material-vivid.sh
+++ b/scripts/base16-material-vivid.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8224, 8481, 9252}
+        set foreground color to {32896, 34438, 35723}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8224, 8481, 9252}
+        set ANSI red color to {62708, 17219, 13878}
+        set ANSI green color to {0, 59110, 30326}
+        set ANSI yellow color to {65535, 60395, 15163}
+        set ANSI blue color to {8481, 38550, 62451}
+        set ANSI magenta color to {26471, 14906, 47031}
+        set ANSI cyan color to {0, 48316, 54484}
+        set ANSI white color to {40606, 40606, 40606}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12850, 13878, 14649}
+        set ANSI bright red color to {62708, 17219, 13878}
+        set ANSI bright green color to {0, 59110, 30326}
+        set ANSI bright yellow color to {65535, 60395, 15163}
+        set ANSI bright blue color to {8481, 38550, 62451}
+        set ANSI bright magenta color to {26471, 14906, 47031}
+        set ANSI bright cyan color to {0, 48316, 54484}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-material.sh
+++ b/scripts/base16-material.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 12850, 14392}
+        set foreground color to {61166, 65535, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 12850, 14392}
+        set ANSI red color to {61680, 29041, 30840}
+        set ANSI green color to {50115, 59624, 36237}
+        set ANSI yellow color to {65535, 52171, 27499}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {51143, 37522, 60138}
+        set ANSI cyan color to {35209, 56797, 65535}
+        set ANSI white color to {61166, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12593, 17733, 18761}
+        set ANSI bright red color to {61680, 29041, 30840}
+        set ANSI bright green color to {50115, 59624, 36237}
+        set ANSI bright yellow color to {65535, 52171, 27499}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {51143, 37522, 60138}
+        set ANSI bright cyan color to {35209, 56797, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-measured-dark.sh
+++ b/scripts/base16-measured-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 8481, 7967}
+        set foreground color to {56540, 56540, 56540}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 8481, 7967}
+        set ANSI red color to {52942, 32382, 36494}
+        set ANSI green color to {22102, 49601, 28527}
+        set ANSI yellow color to {49087, 44204, 20046}
+        set ANSI blue color to {34952, 45232, 56026}
+        set ANSI magenta color to {46003, 39835, 57568}
+        set ANSI cyan color to {25186, 49344, 48830}
+        set ANSI white color to {61423, 61423, 61423}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 21588, 21331}
+        set ANSI bright red color to {52942, 32382, 36494}
+        set ANSI bright green color to {22102, 49601, 28527}
+        set ANSI bright yellow color to {49087, 44204, 20046}
+        set ANSI bright blue color to {34952, 45232, 56026}
+        set ANSI bright magenta color to {46003, 39835, 57568}
+        set ANSI bright cyan color to {25186, 49344, 48830}
+        set ANSI bright white color to {62965, 62965, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-measured-light.sh
+++ b/scripts/base16-measured-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65021, 63993, 62965}
+        set foreground color to {10537, 10537, 10537}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65021, 63993, 62965}
+        set ANSI red color to {44204, 7967, 13621}
+        set ANSI green color to {3084, 26728, 3084}
+        set ANSI yellow color to {25700, 23130, 0}
+        set ANSI blue color to {257, 22616, 44461}
+        set ANSI magenta color to {26214, 17733, 49858}
+        set ANSI cyan color to {257, 29041, 28527}
+        set ANSI white color to {6168, 6168, 6168}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {65535, 60138, 56026}
+        set ANSI bright red color to {44204, 7967, 13621}
+        set ANSI bright green color to {3084, 26728, 3084}
+        set ANSI bright yellow color to {25700, 23130, 0}
+        set ANSI bright blue color to {257, 22616, 44461}
+        set ANSI bright magenta color to {26214, 17733, 49858}
+        set ANSI bright cyan color to {257, 29041, 28527}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-mellow-purple.sh
+++ b/scripts/base16-mellow-purple.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7710, 1285, 10280}
+        set foreground color to {65535, 61166, 65535}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7710, 1285, 10280}
+        set ANSI red color to {0, 55769, 59881}
+        set ANSI green color to {1285, 52171, 3341}
+        set ANSI yellow color to {38293, 23130, 59367}
+        set ANSI blue color to {21845, 0, 26728}
+        set ANSI magenta color to {35209, 37265, 48059}
+        set ANSI cyan color to {47545, 0, 45489}
+        set ANSI white color to {65535, 61166, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13107, 4883, 21588}
+        set ANSI bright red color to {0, 55769, 59881}
+        set ANSI bright green color to {1285, 52171, 3341}
+        set ANSI bright yellow color to {38293, 23130, 59367}
+        set ANSI bright blue color to {21845, 0, 26728}
+        set ANSI bright magenta color to {35209, 37265, 48059}
+        set ANSI bright cyan color to {47545, 0, 45489}
+        set ANSI bright white color to {63736, 49344, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-mexico-light.sh
+++ b/scripts/base16-mexico-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63736, 63736, 63736}
+        set foreground color to {14392, 14392, 14392}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63736, 63736, 63736}
+        set ANSI red color to {43947, 17990, 16962}
+        set ANSI green color to {21331, 35209, 18247}
+        set ANSI yellow color to {63479, 39578, 3598}
+        set ANSI blue color to {31868, 44975, 49858}
+        set ANSI magenta color to {38550, 24672, 40606}
+        set ANSI cyan color to {19275, 32896, 37779}
+        set ANSI white color to {10280, 10280, 10280}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 55512, 55512}
+        set ANSI bright red color to {43947, 17990, 16962}
+        set ANSI bright green color to {21331, 35209, 18247}
+        set ANSI bright yellow color to {63479, 39578, 3598}
+        set ANSI bright blue color to {31868, 44975, 49858}
+        set ANSI bright magenta color to {38550, 24672, 40606}
+        set ANSI bright cyan color to {19275, 32896, 37779}
+        set ANSI bright white color to {6168, 6168, 6168}
+    end tell
+end tell
+EOF

--- a/scripts/base16-mocha.sh
+++ b/scripts/base16-mocha.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {15163, 12850, 10280}
+        set foreground color to {53456, 51400, 50886}
+
+        -- Set ANSI Colors
+        set ANSI black color to {15163, 12850, 10280}
+        set ANSI red color to {52171, 24672, 30583}
+        set ANSI green color to {48830, 46517, 23387}
+        set ANSI yellow color to {62708, 48316, 34695}
+        set ANSI blue color to {35466, 46003, 46517}
+        set ANSI magenta color to {43176, 39835, 47545}
+        set ANSI cyan color to {31611, 48573, 42148}
+        set ANSI white color to {59881, 57825, 56797}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {25700, 21074, 16448}
+        set ANSI bright red color to {52171, 24672, 30583}
+        set ANSI bright green color to {48830, 46517, 23387}
+        set ANSI bright yellow color to {62708, 48316, 34695}
+        set ANSI bright blue color to {35466, 46003, 46517}
+        set ANSI bright magenta color to {43176, 39835, 47545}
+        set ANSI bright cyan color to {31611, 48573, 42148}
+        set ANSI bright white color to {62965, 61166, 60395}
+    end tell
+end tell
+EOF

--- a/scripts/base16-monokai.sh
+++ b/scripts/base16-monokai.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10023, 10280, 8738}
+        set foreground color to {63736, 63736, 62194}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10023, 10280, 8738}
+        set ANSI red color to {63993, 9766, 29298}
+        set ANSI green color to {42662, 58082, 11822}
+        set ANSI yellow color to {62708, 49087, 30069}
+        set ANSI blue color to {26214, 55769, 61423}
+        set ANSI magenta color to {44718, 33153, 65535}
+        set ANSI cyan color to {41377, 61423, 58596}
+        set ANSI white color to {62965, 62708, 61937}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18761, 18504, 15934}
+        set ANSI bright red color to {63993, 9766, 29298}
+        set ANSI bright green color to {42662, 58082, 11822}
+        set ANSI bright yellow color to {62708, 49087, 30069}
+        set ANSI bright blue color to {26214, 55769, 61423}
+        set ANSI bright magenta color to {44718, 33153, 65535}
+        set ANSI bright cyan color to {41377, 61423, 58596}
+        set ANSI bright white color to {63993, 63736, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-moonlight.sh
+++ b/scripts/base16-moonlight.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8481, 8995, 14135}
+        set foreground color to {41891, 44204, 57825}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8481, 8995, 14135}
+        set ANSI red color to {65535, 21331, 28784}
+        set ANSI green color to {11565, 62708, 49344}
+        set ANSI yellow color to {65535, 51143, 30583}
+        set ANSI blue color to {16448, 65535, 65535}
+        set ANSI magenta color to {47545, 38036, 61937}
+        set ANSI cyan color to {1028, 53713, 63993}
+        set ANSI white color to {46260, 42148, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22873, 25443, 39321}
+        set ANSI bright red color to {65535, 21331, 28784}
+        set ANSI bright green color to {11565, 62708, 49344}
+        set ANSI bright yellow color to {65535, 51143, 30583}
+        set ANSI bright blue color to {16448, 65535, 65535}
+        set ANSI bright magenta color to {47545, 38036, 61937}
+        set ANSI bright cyan color to {1028, 53713, 63993}
+        set ANSI bright white color to {61423, 17219, 64250}
+    end tell
+end tell
+EOF

--- a/scripts/base16-mountain.sh
+++ b/scripts/base16-mountain.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3855, 3855, 3855}
+        set foreground color to {51914, 51914, 51914}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3855, 3855, 3855}
+        set ANSI red color to {44204, 35466, 35980}
+        set ANSI green color to {35466, 44204, 35723}
+        set ANSI yellow color to {44204, 43433, 35466}
+        set ANSI blue color to {36751, 35466, 44204}
+        set ANSI magenta color to {44204, 35466, 44204}
+        set ANSI cyan color to {35466, 43947, 44204}
+        set ANSI white color to {59367, 59367, 59367}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {9766, 9766, 9766}
+        set ANSI bright red color to {44204, 35466, 35980}
+        set ANSI bright green color to {35466, 44204, 35723}
+        set ANSI bright yellow color to {44204, 43433, 35466}
+        set ANSI bright blue color to {36751, 35466, 44204}
+        set ANSI bright magenta color to {44204, 35466, 44204}
+        set ANSI bright cyan color to {35466, 43947, 44204}
+        set ANSI bright white color to {61680, 61680, 61680}
+    end tell
+end tell
+EOF

--- a/scripts/base16-nebula.sh
+++ b/scripts/base16-nebula.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 10023, 15163}
+        set foreground color to {42148, 42662, 43433}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 10023, 15163}
+        set ANSI red color to {30583, 31354, 48316}
+        set ANSI green color to {25957, 25186, 43176}
+        set ANSI yellow color to {20303, 37008, 25186}
+        set ANSI blue color to {19789, 27499, 46774}
+        set ANSI magenta color to {29041, 27756, 44718}
+        set ANSI cyan color to {8738, 28527, 26728}
+        set ANSI white color to {51143, 51657, 52685}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 33667, 32896}
+        set ANSI bright red color to {30583, 31354, 48316}
+        set ANSI bright green color to {25957, 25186, 43176}
+        set ANSI bright yellow color to {20303, 37008, 25186}
+        set ANSI bright blue color to {19789, 27499, 46774}
+        set ANSI bright magenta color to {29041, 27756, 44718}
+        set ANSI bright cyan color to {8738, 28527, 26728}
+        set ANSI bright white color to {36237, 48573, 43690}
+    end tell
+end tell
+EOF

--- a/scripts/base16-nord-light.sh
+++ b/scripts/base16-nord-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {58853, 59881, 61680}
+        set foreground color to {11822, 13364, 16448}
+
+        -- Set ANSI Colors
+        set ANSI black color to {58853, 59881, 61680}
+        set ANSI red color to {39321, 12850, 19275}
+        set ANSI green color to {20303, 35209, 19532}
+        set ANSI yellow color to {39578, 30069, 0}
+        set ANSI blue color to {15163, 28270, 43176}
+        set ANSI magenta color to {38807, 13878, 23387}
+        set ANSI cyan color to {14649, 36494, 44204}
+        set ANSI white color to {15163, 16962, 21074}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {47288, 50629, 56283}
+        set ANSI bright red color to {39321, 12850, 19275}
+        set ANSI bright green color to {20303, 35209, 19532}
+        set ANSI bright yellow color to {39578, 30069, 0}
+        set ANSI bright blue color to {15163, 28270, 43176}
+        set ANSI bright magenta color to {38807, 13878, 23387}
+        set ANSI bright cyan color to {14649, 36494, 44204}
+        set ANSI bright white color to {10537, 33667, 36237}
+    end tell
+end tell
+EOF

--- a/scripts/base16-nord.sh
+++ b/scripts/base16-nord.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11822, 13364, 16448}
+        set foreground color to {58853, 59881, 61680}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11822, 13364, 16448}
+        set ANSI red color to {49087, 24929, 27242}
+        set ANSI green color to {41891, 48830, 35980}
+        set ANSI yellow color to {60395, 52171, 35723}
+        set ANSI blue color to {33153, 41377, 49601}
+        set ANSI magenta color to {46260, 36494, 44461}
+        set ANSI cyan color to {34952, 49344, 53456}
+        set ANSI white color to {60652, 61423, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17219, 19532, 24158}
+        set ANSI bright red color to {49087, 24929, 27242}
+        set ANSI bright green color to {41891, 48830, 35980}
+        set ANSI bright yellow color to {60395, 52171, 35723}
+        set ANSI bright blue color to {33153, 41377, 49601}
+        set ANSI bright magenta color to {46260, 36494, 44461}
+        set ANSI bright cyan color to {34952, 49344, 53456}
+        set ANSI bright white color to {36751, 48316, 48059}
+    end tell
+end tell
+EOF

--- a/scripts/base16-nova.sh
+++ b/scripts/base16-nova.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {15420, 19532, 21845}
+        set foreground color to {50629, 54484, 56797}
+
+        -- Set ANSI Colors
+        set ANSI black color to {15420, 19532, 21845}
+        set ANSI red color to {33667, 44975, 58853}
+        set ANSI green color to {32639, 49601, 51914}
+        set ANSI yellow color to {43176, 52942, 37779}
+        set ANSI blue color to {33667, 44975, 58853}
+        set ANSI magenta color to {39578, 37779, 57825}
+        set ANSI cyan color to {62194, 50115, 36751}
+        set ANSI white color to {35209, 39835, 42662}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {27242, 32125, 35209}
+        set ANSI bright red color to {33667, 44975, 58853}
+        set ANSI bright green color to {32639, 49601, 51914}
+        set ANSI bright yellow color to {43176, 52942, 37779}
+        set ANSI bright blue color to {33667, 44975, 58853}
+        set ANSI bright magenta color to {39578, 37779, 57825}
+        set ANSI bright cyan color to {62194, 50115, 36751}
+        set ANSI bright white color to {21845, 26728, 29555}
+    end tell
+end tell
+EOF

--- a/scripts/base16-ocean.sh
+++ b/scripts/base16-ocean.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11051, 12336, 15163}
+        set foreground color to {49344, 50629, 52942}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11051, 12336, 15163}
+        set ANSI red color to {49087, 24929, 27242}
+        set ANSI green color to {41891, 48830, 35980}
+        set ANSI yellow color to {60395, 52171, 35723}
+        set ANSI blue color to {36751, 41377, 46003}
+        set ANSI magenta color to {46260, 36494, 44461}
+        set ANSI cyan color to {38550, 46517, 46260}
+        set ANSI white color to {57311, 57825, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20303, 23387, 26214}
+        set ANSI bright red color to {49087, 24929, 27242}
+        set ANSI bright green color to {41891, 48830, 35980}
+        set ANSI bright yellow color to {60395, 52171, 35723}
+        set ANSI bright blue color to {36751, 41377, 46003}
+        set ANSI bright magenta color to {46260, 36494, 44461}
+        set ANSI bright cyan color to {38550, 46517, 46260}
+        set ANSI bright white color to {61423, 61937, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-oceanicnext.sh
+++ b/scripts/base16-oceanicnext.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6939, 11051, 13364}
+        set foreground color to {49344, 50629, 52942}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6939, 11051, 13364}
+        set ANSI red color to {60652, 24415, 26471}
+        set ANSI green color to {39321, 51143, 38036}
+        set ANSI yellow color to {64250, 51400, 25443}
+        set ANSI blue color to {26214, 39321, 52428}
+        set ANSI magenta color to {50629, 38036, 50629}
+        set ANSI cyan color to {24415, 46003, 46003}
+        set ANSI white color to {52685, 54227, 57054}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20303, 23387, 26214}
+        set ANSI bright red color to {60652, 24415, 26471}
+        set ANSI bright green color to {39321, 51143, 38036}
+        set ANSI bright yellow color to {64250, 51400, 25443}
+        set ANSI bright blue color to {26214, 39321, 52428}
+        set ANSI bright magenta color to {50629, 38036, 50629}
+        set ANSI bright cyan color to {24415, 46003, 46003}
+        set ANSI bright white color to {55512, 57054, 59881}
+    end tell
+end tell
+EOF

--- a/scripts/base16-one-light.sh
+++ b/scripts/base16-one-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 64250, 64250}
+        set foreground color to {14392, 14906, 16962}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 64250, 64250}
+        set ANSI red color to {51914, 4626, 17219}
+        set ANSI green color to {20560, 41377, 20303}
+        set ANSI yellow color to {49601, 33924, 257}
+        set ANSI blue color to {16448, 30840, 62194}
+        set ANSI magenta color to {42662, 9766, 42148}
+        set ANSI cyan color to {257, 33924, 48316}
+        set ANSI white color to {8224, 8738, 10023}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {58853, 58853, 59110}
+        set ANSI bright red color to {51914, 4626, 17219}
+        set ANSI bright green color to {20560, 41377, 20303}
+        set ANSI bright yellow color to {49601, 33924, 257}
+        set ANSI bright blue color to {16448, 30840, 62194}
+        set ANSI bright magenta color to {42662, 9766, 42148}
+        set ANSI bright cyan color to {257, 33924, 48316}
+        set ANSI bright white color to {2313, 2570, 2827}
+    end tell
+end tell
+EOF

--- a/scripts/base16-onedark-dark.sh
+++ b/scripts/base16-onedark-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {43947, 45746, 49087}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {61423, 22873, 28527}
+        set ANSI green color to {35209, 51914, 30840}
+        set ANSI yellow color to {58853, 49344, 31611}
+        set ANSI blue color to {24929, 44975, 61423}
+        set ANSI magenta color to {54741, 24415, 57054}
+        set ANSI cyan color to {11051, 47802, 50629}
+        set ANSI white color to {46774, 48573, 51914}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11308, 12593, 14906}
+        set ANSI bright red color to {61423, 22873, 28527}
+        set ANSI bright green color to {35209, 51914, 30840}
+        set ANSI bright yellow color to {58853, 49344, 31611}
+        set ANSI bright blue color to {24929, 44975, 61423}
+        set ANSI bright magenta color to {54741, 24415, 57054}
+        set ANSI bright cyan color to {11051, 47802, 50629}
+        set ANSI bright white color to {51400, 52428, 54484}
+    end tell
+end tell
+EOF

--- a/scripts/base16-onedark.sh
+++ b/scripts/base16-onedark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 11308, 13364}
+        set foreground color to {43947, 45746, 49087}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 11308, 13364}
+        set ANSI red color to {57568, 27756, 30069}
+        set ANSI green color to {39064, 50115, 31097}
+        set ANSI yellow color to {58853, 49344, 31611}
+        set ANSI blue color to {24929, 44975, 61423}
+        set ANSI magenta color to {50886, 30840, 56797}
+        set ANSI cyan color to {22102, 46774, 49858}
+        set ANSI white color to {46774, 48573, 51914}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15934, 17476, 20817}
+        set ANSI bright red color to {57568, 27756, 30069}
+        set ANSI bright green color to {39064, 50115, 31097}
+        set ANSI bright yellow color to {58853, 49344, 31611}
+        set ANSI bright blue color to {24929, 44975, 61423}
+        set ANSI bright magenta color to {50886, 30840, 56797}
+        set ANSI bright cyan color to {22102, 46774, 49858}
+        set ANSI bright white color to {51400, 52428, 54484}
+    end tell
+end tell
+EOF

--- a/scripts/base16-outrun-dark.sh
+++ b/scripts/base16-outrun-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 10794}
+        set foreground color to {53456, 53456, 64250}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 10794}
+        set ANSI red color to {65535, 16962, 16962}
+        set ANSI green color to {22873, 61937, 30326}
+        set ANSI yellow color to {62451, 59624, 30583}
+        set ANSI blue color to {26214, 45232, 65535}
+        set ANSI magenta color to {61937, 1285, 38550}
+        set ANSI cyan color to {3598, 61680, 61680}
+        set ANSI white color to {57568, 57568, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 23130}
+        set ANSI bright red color to {65535, 16962, 16962}
+        set ANSI bright green color to {22873, 61937, 30326}
+        set ANSI bright yellow color to {62451, 59624, 30583}
+        set ANSI bright blue color to {26214, 45232, 65535}
+        set ANSI bright magenta color to {61937, 1285, 38550}
+        set ANSI bright cyan color to {3598, 61680, 61680}
+        set ANSI bright white color to {62965, 62965, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-oxocarbon-dark.sh
+++ b/scripts/base16-oxocarbon-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5654, 5654, 5654}
+        set foreground color to {62194, 62708, 63736}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5654, 5654, 5654}
+        set ANSI red color to {15677, 56283, 55769}
+        set ANSI green color to {13107, 45489, 65535}
+        set ANSI yellow color to {61166, 21331, 38550}
+        set ANSI blue color to {16962, 48830, 25957}
+        set ANSI magenta color to {48830, 38293, 65535}
+        set ANSI cyan color to {65535, 32382, 46774}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14649, 14649, 14649}
+        set ANSI bright red color to {15677, 56283, 55769}
+        set ANSI bright green color to {13107, 45489, 65535}
+        set ANSI bright yellow color to {61166, 21331, 38550}
+        set ANSI bright blue color to {16962, 48830, 25957}
+        set ANSI bright magenta color to {48830, 38293, 65535}
+        set ANSI bright cyan color to {65535, 32382, 46774}
+        set ANSI bright white color to {2056, 48573, 47802}
+    end tell
+end tell
+EOF

--- a/scripts/base16-oxocarbon-light.sh
+++ b/scripts/base16-oxocarbon-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62194, 62708, 63736}
+        set foreground color to {14649, 14649, 14649}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62194, 62708, 63736}
+        set ANSI red color to {65535, 32382, 46774}
+        set ANSI green color to {3855, 25186, 65278}
+        set ANSI yellow color to {65535, 28527, 0}
+        set ANSI blue color to {16962, 48830, 25957}
+        set ANSI magenta color to {48830, 38293, 65535}
+        set ANSI cyan color to {26471, 14906, 47031}
+        set ANSI white color to {21074, 21074, 21074}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21074, 21074, 21074}
+        set ANSI bright red color to {65535, 32382, 46774}
+        set ANSI bright green color to {3855, 25186, 65278}
+        set ANSI bright yellow color to {65535, 28527, 0}
+        set ANSI bright blue color to {16962, 48830, 25957}
+        set ANSI bright magenta color to {48830, 38293, 65535}
+        set ANSI bright cyan color to {26471, 14906, 47031}
+        set ANSI bright white color to {2056, 48573, 47802}
+    end tell
+end tell
+EOF

--- a/scripts/base16-pandora.sh
+++ b/scripts/base16-pandora.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4883, 4626, 4883}
+        set foreground color to {61937, 23644, 39321}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4883, 4626, 4883}
+        set ANSI red color to {45232, 2827, 26985}
+        set ANSI green color to {40349, 57311, 26985}
+        set ANSI yellow color to {65535, 52428, 0}
+        set ANSI blue color to {0, 32896, 32896}
+        set ANSI magenta color to {41634, 16448, 12336}
+        set ANSI cyan color to {29041, 19532, 42662}
+        set ANSI white color to {33153, 20560, 27242}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18247, 8738, 13364}
+        set ANSI bright red color to {45232, 2827, 26985}
+        set ANSI bright green color to {40349, 57311, 26985}
+        set ANSI bright yellow color to {65535, 52428, 0}
+        set ANSI bright blue color to {0, 32896, 32896}
+        set ANSI bright magenta color to {41634, 16448, 12336}
+        set ANSI bright cyan color to {29041, 19532, 42662}
+        set ANSI bright white color to {25443, 8738, 10023}
+    end tell
+end tell
+EOF

--- a/scripts/base16-papercolor-dark.sh
+++ b/scripts/base16-papercolor-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 7196, 7196}
+        set foreground color to {32896, 32896, 32896}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 7196, 7196}
+        set ANSI red color to {22616, 22616, 22616}
+        set ANSI green color to {44975, 34695, 55255}
+        set ANSI yellow color to {44975, 55255, 0}
+        set ANSI blue color to {65535, 24415, 44975}
+        set ANSI magenta color to {0, 44975, 44975}
+        set ANSI cyan color to {65535, 44975, 0}
+        set ANSI white color to {55255, 34695, 24415}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24415, 44975, 0}
+        set ANSI bright red color to {22616, 22616, 22616}
+        set ANSI bright green color to {44975, 34695, 55255}
+        set ANSI bright yellow color to {44975, 55255, 0}
+        set ANSI bright blue color to {65535, 24415, 44975}
+        set ANSI bright magenta color to {0, 44975, 44975}
+        set ANSI bright cyan color to {65535, 44975, 0}
+        set ANSI bright white color to {53456, 53456, 53456}
+    end tell
+end tell
+EOF

--- a/scripts/base16-papercolor-light.sh
+++ b/scripts/base16-papercolor-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61166, 61166, 61166}
+        set foreground color to {17476, 17476, 17476}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61166, 61166, 61166}
+        set ANSI red color to {48316, 48316, 48316}
+        set ANSI green color to {34695, 0, 44975}
+        set ANSI yellow color to {55255, 0, 34695}
+        set ANSI blue color to {55255, 24415, 0}
+        set ANSI magenta color to {0, 24415, 44975}
+        set ANSI cyan color to {55255, 24415, 0}
+        set ANSI white color to {0, 24415, 34695}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 34695, 0}
+        set ANSI bright red color to {48316, 48316, 48316}
+        set ANSI bright green color to {34695, 0, 44975}
+        set ANSI bright yellow color to {55255, 0, 34695}
+        set ANSI bright blue color to {55255, 24415, 0}
+        set ANSI bright magenta color to {0, 24415, 44975}
+        set ANSI bright cyan color to {55255, 24415, 0}
+        set ANSI bright white color to {34695, 34695, 34695}
+    end tell
+end tell
+EOF

--- a/scripts/base16-paraiso.sh
+++ b/scripts/base16-paraiso.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {12079, 7710, 11822}
+        set foreground color to {41891, 40606, 39835}
+
+        -- Set ANSI Colors
+        set ANSI black color to {12079, 7710, 11822}
+        set ANSI red color to {61423, 24929, 21845}
+        set ANSI green color to {18504, 46774, 34181}
+        set ANSI yellow color to {65278, 50372, 6168}
+        set ANSI blue color to {1542, 46774, 61423}
+        set ANSI magenta color to {33153, 23387, 42148}
+        set ANSI cyan color to {23387, 50372, 49087}
+        set ANSI white color to {47545, 46774, 45232}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20303, 16962, 19532}
+        set ANSI bright red color to {61423, 24929, 21845}
+        set ANSI bright green color to {18504, 46774, 34181}
+        set ANSI bright yellow color to {65278, 50372, 6168}
+        set ANSI bright blue color to {1542, 46774, 61423}
+        set ANSI bright magenta color to {33153, 23387, 42148}
+        set ANSI bright cyan color to {23387, 50372, 49087}
+        set ANSI bright white color to {59367, 59881, 56283}
+    end tell
+end tell
+EOF

--- a/scripts/base16-pasque.sh
+++ b/scripts/base16-pasque.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10023, 7196, 14906}
+        set foreground color to {57054, 56540, 57311}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10023, 7196, 14906}
+        set ANSI red color to {43433, 8738, 22616}
+        set ANSI green color to {50886, 37265, 19275}
+        set ANSI yellow color to {32896, 20046, 44461}
+        set ANSI blue color to {36494, 32125, 50886}
+        set ANSI magenta color to {38293, 15163, 40349}
+        set ANSI cyan color to {29298, 25443, 43690}
+        set ANSI white color to {60909, 60138, 61423}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15934, 11565, 23644}
+        set ANSI bright red color to {43433, 8738, 22616}
+        set ANSI bright green color to {50886, 37265, 19275}
+        set ANSI bright yellow color to {32896, 20046, 44461}
+        set ANSI bright blue color to {36494, 32125, 50886}
+        set ANSI bright magenta color to {38293, 15163, 40349}
+        set ANSI bright cyan color to {29298, 25443, 43690}
+        set ANSI bright white color to {48059, 43690, 56797}
+    end tell
+end tell
+EOF

--- a/scripts/base16-phd.sh
+++ b/scripts/base16-phd.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1542, 4626, 10537}
+        set foreground color to {47288, 48059, 49858}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1542, 4626, 10537}
+        set ANSI red color to {53456, 29555, 17990}
+        set ANSI green color to {39321, 49087, 21074}
+        set ANSI yellow color to {64507, 54484, 24929}
+        set ANSI blue color to {21074, 39321, 49087}
+        set ANSI magenta color to {39321, 35209, 52428}
+        set ANSI cyan color to {29298, 47545, 49087}
+        set ANSI white color to {56283, 56797, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19789, 22102, 26214}
+        set ANSI bright red color to {53456, 29555, 17990}
+        set ANSI bright green color to {39321, 49087, 21074}
+        set ANSI bright yellow color to {64507, 54484, 24929}
+        set ANSI bright blue color to {21074, 39321, 49087}
+        set ANSI bright magenta color to {39321, 35209, 52428}
+        set ANSI bright cyan color to {29298, 47545, 49087}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-pico.sh
+++ b/scripts/base16-pico.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {24415, 22359, 20303}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {65535, 0, 19789}
+        set ANSI green color to {0, 59367, 22102}
+        set ANSI yellow color to {65535, 61680, 9252}
+        set ANSI blue color to {33667, 30326, 40092}
+        set ANSI magenta color to {65535, 30583, 43176}
+        set ANSI cyan color to {10537, 44461, 65535}
+        set ANSI white color to {49858, 50115, 51143}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {32382, 9509, 21331}
+        set ANSI bright red color to {65535, 0, 19789}
+        set ANSI bright green color to {0, 59367, 22102}
+        set ANSI bright yellow color to {65535, 61680, 9252}
+        set ANSI bright blue color to {33667, 30326, 40092}
+        set ANSI bright magenta color to {65535, 30583, 43176}
+        set ANSI bright cyan color to {10537, 44461, 65535}
+        set ANSI bright white color to {65535, 61937, 59624}
+    end tell
+end tell
+EOF

--- a/scripts/base16-pinky.sh
+++ b/scripts/base16-pinky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 5397, 5911}
+        set foreground color to {62965, 62965, 62965}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 5397, 5911}
+        set ANSI red color to {65535, 42662, 0}
+        set ANSI green color to {65535, 0, 26214}
+        set ANSI yellow color to {8224, 57311, 27756}
+        set ANSI blue color to {0, 65535, 65535}
+        set ANSI magenta color to {0, 32639, 65535}
+        set ANSI cyan color to {26214, 0, 65535}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {7453, 6939, 7453}
+        set ANSI bright red color to {65535, 42662, 0}
+        set ANSI bright green color to {65535, 0, 26214}
+        set ANSI bright yellow color to {8224, 57311, 27756}
+        set ANSI bright blue color to {0, 65535, 65535}
+        set ANSI bright magenta color to {0, 32639, 65535}
+        set ANSI bright cyan color to {26214, 0, 65535}
+        set ANSI bright white color to {63479, 62451, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-pop.sh
+++ b/scripts/base16-pop.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {60395, 0, 35466}
+        set ANSI green color to {14135, 46003, 18761}
+        set ANSI yellow color to {63736, 51914, 4626}
+        set ANSI blue color to {3598, 23130, 38036}
+        set ANSI magenta color to {46003, 7710, 36237}
+        set ANSI cyan color to {0, 43690, 48059}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {60395, 0, 35466}
+        set ANSI bright green color to {14135, 46003, 18761}
+        set ANSI bright yellow color to {63736, 51914, 4626}
+        set ANSI bright blue color to {3598, 23130, 38036}
+        set ANSI bright magenta color to {46003, 7710, 36237}
+        set ANSI bright cyan color to {0, 43690, 48059}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-porple.sh
+++ b/scripts/base16-porple.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 11308, 13878}
+        set foreground color to {55512, 55512, 55512}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 11308, 13878}
+        set ANSI red color to {63736, 17733, 18247}
+        set ANSI green color to {38293, 51143, 28527}
+        set ANSI yellow color to {61423, 41377, 27499}
+        set ANSI blue color to {33924, 34181, 52942}
+        set ANSI magenta color to {47031, 18761, 35209}
+        set ANSI cyan color to {25700, 34695, 36751}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18247, 16705, 24672}
+        set ANSI bright red color to {63736, 17733, 18247}
+        set ANSI bright green color to {38293, 51143, 28527}
+        set ANSI bright yellow color to {61423, 41377, 27499}
+        set ANSI bright blue color to {33924, 34181, 52942}
+        set ANSI bright magenta color to {47031, 18761, 35209}
+        set ANSI bright cyan color to {25700, 34695, 36751}
+        set ANSI bright white color to {63736, 63736, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-precious-dark-eleven.sh
+++ b/scripts/base16-precious-dark-eleven.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 7710, 8224}
+        set foreground color to {47288, 47031, 46774}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 7710, 8224}
+        set ANSI red color to {65535, 34695, 33410}
+        set ANSI green color to {38293, 46774, 22616}
+        set ANSI yellow color to {53456, 42405, 17219}
+        set ANSI blue color to {26728, 45232, 61166}
+        set ANSI magenta color to {47031, 39321, 65278}
+        set ANSI cyan color to {16962, 48573, 42919}
+        set ANSI white color to {47288, 47031, 46774}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14135, 14649, 14906}
+        set ANSI bright red color to {65535, 34695, 33410}
+        set ANSI bright green color to {38293, 46774, 22616}
+        set ANSI bright yellow color to {53456, 42405, 17219}
+        set ANSI bright blue color to {26728, 45232, 61166}
+        set ANSI bright magenta color to {47031, 39321, 65278}
+        set ANSI bright cyan color to {16962, 48573, 42919}
+        set ANSI bright white color to {47288, 47031, 46774}
+    end tell
+end tell
+EOF

--- a/scripts/base16-precious-dark-fifteen.sh
+++ b/scripts/base16-precious-dark-fifteen.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 9766, 11051}
+        set foreground color to {47802, 47545, 46774}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 9766, 11051}
+        set ANSI red color to {65535, 34695, 33410}
+        set ANSI green color to {38293, 46774, 22873}
+        set ANSI yellow color to {53199, 42405, 17990}
+        set ANSI blue color to {26214, 45232, 61423}
+        set ANSI magenta color to {47031, 39321, 65535}
+        set ANSI cyan color to {16962, 48573, 42919}
+        set ANSI white color to {47802, 47545, 46774}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15934, 16448, 17476}
+        set ANSI bright red color to {65535, 34695, 33410}
+        set ANSI bright green color to {38293, 46774, 22873}
+        set ANSI bright yellow color to {53199, 42405, 17990}
+        set ANSI bright blue color to {26214, 45232, 61423}
+        set ANSI bright magenta color to {47031, 39321, 65535}
+        set ANSI bright cyan color to {16962, 48573, 42919}
+        set ANSI bright white color to {47802, 47545, 46774}
+    end tell
+end tell
+EOF

--- a/scripts/base16-precious-light-warm.sh
+++ b/scripts/base16-precious-light-warm.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 62965, 58853}
+        set foreground color to {20046, 21331, 22873}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 62965, 58853}
+        set ANSI red color to {45489, 18247, 17733}
+        set ANSI green color to {21845, 29555, 0}
+        set ANSI yellow color to {34695, 25957, 0}
+        set ANSI blue color to {9252, 28013, 42405}
+        set ANSI magenta color to {31354, 20560, 50886}
+        set ANSI cyan color to {3598, 30583, 26471}
+        set ANSI white color to {20046, 21331, 22873}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55769, 54227, 51400}
+        set ANSI bright red color to {45489, 18247, 17733}
+        set ANSI bright green color to {21845, 29555, 0}
+        set ANSI bright yellow color to {34695, 25957, 0}
+        set ANSI bright blue color to {9252, 28013, 42405}
+        set ANSI bright magenta color to {31354, 20560, 50886}
+        set ANSI bright cyan color to {3598, 30583, 26471}
+        set ANSI bright white color to {20046, 21331, 22873}
+    end tell
+end tell
+EOF

--- a/scripts/base16-precious-light-white.sh
+++ b/scripts/base16-precious-light-white.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {21845, 21845, 21845}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {44975, 18761, 18247}
+        set ANSI green color to {21845, 29555, 257}
+        set ANSI yellow color to {34695, 25957, 0}
+        set ANSI blue color to {6168, 28013, 43690}
+        set ANSI magenta color to {31611, 20046, 52171}
+        set ANSI cyan color to {2056, 30583, 26471}
+        set ANSI white color to {21845, 21845, 21845}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {56283, 56283, 56283}
+        set ANSI bright red color to {44975, 18761, 18247}
+        set ANSI bright green color to {21845, 29555, 257}
+        set ANSI bright yellow color to {34695, 25957, 0}
+        set ANSI bright blue color to {6168, 28013, 43690}
+        set ANSI bright magenta color to {31611, 20046, 52171}
+        set ANSI bright cyan color to {2056, 30583, 26471}
+        set ANSI bright white color to {21845, 21845, 21845}
+    end tell
+end tell
+EOF

--- a/scripts/base16-primer-dark-dimmed.sh
+++ b/scripts/base16-primer-dark-dimmed.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 8481, 10280}
+        set foreground color to {37008, 40349, 43947}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 8481, 10280}
+        set ANSI red color to {62708, 28784, 26471}
+        set ANSI green color to {22359, 43947, 23130}
+        set ANSI yellow color to {50886, 37008, 9766}
+        set ANSI blue color to {21331, 39835, 62965}
+        set ANSI magenta color to {58082, 30069, 44461}
+        set ANSI cyan color to {38550, 53456, 65535}
+        set ANSI white color to {44461, 47802, 51143}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17476, 19532, 22102}
+        set ANSI bright red color to {62708, 28784, 26471}
+        set ANSI bright green color to {22359, 43947, 23130}
+        set ANSI bright yellow color to {50886, 37008, 9766}
+        set ANSI bright blue color to {21331, 39835, 62965}
+        set ANSI bright magenta color to {58082, 30069, 44461}
+        set ANSI bright cyan color to {38550, 53456, 65535}
+        set ANSI bright white color to {52685, 55769, 58853}
+    end tell
+end tell
+EOF

--- a/scripts/base16-primer-dark.sh
+++ b/scripts/base16-primer-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {257, 1028, 2313}
+        set foreground color to {45489, 47802, 50372}
+
+        -- Set ANSI Colors
+        set ANSI black color to {257, 1028, 2313}
+        set ANSI red color to {65535, 31611, 29298}
+        set ANSI green color to {16191, 47545, 20560}
+        set ANSI yellow color to {53970, 39321, 8738}
+        set ANSI blue color to {22616, 42662, 65535}
+        set ANSI magenta color to {63479, 30840, 47802}
+        set ANSI cyan color to {42405, 54998, 65535}
+        set ANSI white color to {51657, 53713, 55769}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 13878, 15677}
+        set ANSI bright red color to {65535, 31611, 29298}
+        set ANSI bright green color to {16191, 47545, 20560}
+        set ANSI bright yellow color to {53970, 39321, 8738}
+        set ANSI bright blue color to {22616, 42662, 65535}
+        set ANSI bright magenta color to {63479, 30840, 47802}
+        set ANSI bright cyan color to {42405, 54998, 65535}
+        set ANSI bright white color to {61680, 63222, 64764}
+    end tell
+end tell
+EOF

--- a/scripts/base16-primer-light.sh
+++ b/scripts/base16-primer-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 64507, 64764}
+        set foreground color to {12079, 13878, 15677}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 64507, 64764}
+        set ANSI red color to {55255, 14906, 18761}
+        set ANSI green color to {10280, 42919, 17733}
+        set ANSI yellow color to {65535, 54227, 15677}
+        set ANSI blue color to {771, 26214, 54998}
+        set ANSI magenta color to {60138, 19018, 43690}
+        set ANSI cyan color to {31097, 47288, 65535}
+        set ANSI white color to {9252, 10537, 11822}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {53713, 54741, 56026}
+        set ANSI bright red color to {55255, 14906, 18761}
+        set ANSI bright green color to {10280, 42919, 17733}
+        set ANSI bright yellow color to {65535, 54227, 15677}
+        set ANSI bright blue color to {771, 26214, 54998}
+        set ANSI bright magenta color to {60138, 19018, 43690}
+        set ANSI bright cyan color to {31097, 47288, 65535}
+        set ANSI bright white color to {6939, 7967, 8995}
+    end tell
+end tell
+EOF

--- a/scripts/base16-purpledream.sh
+++ b/scripts/base16-purpledream.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 1285, 4112}
+        set foreground color to {56797, 53456, 56797}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 1285, 4112}
+        set ANSI red color to {65535, 7453, 3341}
+        set ANSI green color to {5140, 52428, 25700}
+        set ANSI yellow color to {61680, 0, 41120}
+        set ANSI blue color to {0, 41120, 61680}
+        set ANSI magenta color to {45232, 0, 53456}
+        set ANSI cyan color to {0, 30069, 45232}
+        set ANSI white color to {61166, 57568, 61166}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16448, 12336, 16448}
+        set ANSI bright red color to {65535, 7453, 3341}
+        set ANSI bright green color to {5140, 52428, 25700}
+        set ANSI bright yellow color to {61680, 0, 41120}
+        set ANSI bright blue color to {0, 41120, 61680}
+        set ANSI bright magenta color to {45232, 0, 53456}
+        set ANSI bright cyan color to {0, 30069, 45232}
+        set ANSI bright white color to {65535, 61680, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-qualia.sh
+++ b/scripts/base16-qualia.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 4112, 4112}
+        set foreground color to {49344, 49344, 49344}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 4112, 4112}
+        set ANSI red color to {61423, 42662, 41634}
+        set ANSI green color to {32896, 51657, 37008}
+        set ANSI yellow color to {59110, 41891, 56540}
+        set ANSI blue color to {20560, 51914, 52685}
+        set ANSI magenta color to {57568, 44975, 34181}
+        set ANSI cyan color to {51400, 51400, 29812}
+        set ANSI white color to {49344, 49344, 49344}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17733, 17733, 17733}
+        set ANSI bright red color to {61423, 42662, 41634}
+        set ANSI bright green color to {32896, 51657, 37008}
+        set ANSI bright yellow color to {59110, 41891, 56540}
+        set ANSI bright blue color to {20560, 51914, 52685}
+        set ANSI bright magenta color to {57568, 44975, 34181}
+        set ANSI bright cyan color to {51400, 51400, 29812}
+        set ANSI bright white color to {17733, 17733, 17733}
+    end tell
+end tell
+EOF

--- a/scripts/base16-railscasts.sh
+++ b/scripts/base16-railscasts.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11051, 11051, 11051}
+        set foreground color to {59110, 57825, 56540}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11051, 11051, 11051}
+        set ANSI red color to {56026, 18761, 14649}
+        set ANSI green color to {42405, 49858, 24929}
+        set ANSI yellow color to {65535, 50886, 28013}
+        set ANSI blue color to {28013, 40092, 48830}
+        set ANSI magenta color to {46774, 46003, 60395}
+        set ANSI cyan color to {20817, 40863, 20560}
+        set ANSI white color to {62708, 61937, 60909}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14906, 16448, 21845}
+        set ANSI bright red color to {56026, 18761, 14649}
+        set ANSI bright green color to {42405, 49858, 24929}
+        set ANSI bright yellow color to {65535, 50886, 28013}
+        set ANSI bright blue color to {28013, 40092, 48830}
+        set ANSI bright magenta color to {46774, 46003, 60395}
+        set ANSI bright cyan color to {20817, 40863, 20560}
+        set ANSI bright white color to {63993, 63479, 62451}
+    end tell
+end tell
+EOF

--- a/scripts/base16-rebecca.sh
+++ b/scripts/base16-rebecca.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10537, 10794, 17476}
+        set foreground color to {61937, 61423, 63736}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10537, 10794, 17476}
+        set ANSI red color to {41120, 41120, 50629}
+        set ANSI green color to {28013, 65278, 57311}
+        set ANSI yellow color to {44718, 33153, 65535}
+        set ANSI blue color to {11565, 57568, 42919}
+        set ANSI magenta color to {31354, 42405, 65535}
+        set ANSI cyan color to {36494, 44718, 57568}
+        set ANSI white color to {52428, 52428, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14392, 14906, 25186}
+        set ANSI bright red color to {41120, 41120, 50629}
+        set ANSI bright green color to {28013, 65278, 57311}
+        set ANSI bright yellow color to {44718, 33153, 65535}
+        set ANSI bright blue color to {11565, 57568, 42919}
+        set ANSI bright magenta color to {31354, 42405, 65535}
+        set ANSI bright cyan color to {36494, 44718, 57568}
+        set ANSI bright white color to {21331, 18761, 23901}
+    end tell
+end tell
+EOF

--- a/scripts/base16-rose-pine-dawn.sh
+++ b/scripts/base16-rose-pine-dawn.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64250, 62708, 60909}
+        set foreground color to {22359, 21074, 31097}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64250, 62708, 60909}
+        set ANSI red color to {46260, 25443, 31354}
+        set ANSI green color to {10280, 26985, 33667}
+        set ANSI yellow color to {55255, 33410, 32382}
+        set ANSI blue color to {37008, 31354, 43433}
+        set ANSI magenta color to {60138, 40349, 13364}
+        set ANSI cyan color to {22102, 38036, 40863}
+        set ANSI white color to {22359, 21074, 31097}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {62194, 59881, 57054}
+        set ANSI bright red color to {46260, 25443, 31354}
+        set ANSI bright green color to {10280, 26985, 33667}
+        set ANSI bright yellow color to {55255, 33410, 32382}
+        set ANSI bright blue color to {37008, 31354, 43433}
+        set ANSI bright magenta color to {60138, 40349, 13364}
+        set ANSI bright cyan color to {22102, 38036, 40863}
+        set ANSI bright white color to {52942, 51914, 52685}
+    end tell
+end tell
+EOF

--- a/scripts/base16-rose-pine-moon.sh
+++ b/scripts/base16-rose-pine-moon.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 8481, 13878}
+        set foreground color to {57568, 57054, 62708}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 8481, 13878}
+        set ANSI red color to {60395, 28527, 37522}
+        set ANSI green color to {15934, 36751, 45232}
+        set ANSI yellow color to {60138, 39578, 38807}
+        set ANSI blue color to {50372, 42919, 59367}
+        set ANSI magenta color to {63222, 49601, 30583}
+        set ANSI cyan color to {40092, 53199, 55512}
+        set ANSI white color to {57568, 57054, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14649, 13621, 21074}
+        set ANSI bright red color to {60395, 28527, 37522}
+        set ANSI bright green color to {15934, 36751, 45232}
+        set ANSI bright yellow color to {60138, 39578, 38807}
+        set ANSI bright blue color to {50372, 42919, 59367}
+        set ANSI bright magenta color to {63222, 49601, 30583}
+        set ANSI bright cyan color to {40092, 53199, 55512}
+        set ANSI bright white color to {22102, 21074, 28270}
+    end tell
+end tell
+EOF

--- a/scripts/base16-rose-pine.sh
+++ b/scripts/base16-rose-pine.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6425, 5911, 9252}
+        set foreground color to {57568, 57054, 62708}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6425, 5911, 9252}
+        set ANSI red color to {60395, 28527, 37522}
+        set ANSI green color to {12593, 29812, 36751}
+        set ANSI yellow color to {60395, 48316, 47802}
+        set ANSI blue color to {50372, 42919, 59367}
+        set ANSI magenta color to {63222, 49601, 30583}
+        set ANSI cyan color to {40092, 53199, 55512}
+        set ANSI white color to {57568, 57054, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {9766, 8995, 14906}
+        set ANSI bright red color to {60395, 28527, 37522}
+        set ANSI bright green color to {12593, 29812, 36751}
+        set ANSI bright yellow color to {60395, 48316, 47802}
+        set ANSI bright blue color to {50372, 42919, 59367}
+        set ANSI bright magenta color to {63222, 49601, 30583}
+        set ANSI bright cyan color to {40092, 53199, 55512}
+        set ANSI bright white color to {21074, 20303, 26471}
+    end tell
+end tell
+EOF

--- a/scripts/base16-saga.sh
+++ b/scripts/base16-saga.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1285, 2056, 2570}
+        set foreground color to {56540, 58082, 63479}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1285, 2056, 2570}
+        set ANSI red color to {65535, 54484, 59881}
+        set ANSI green color to {63479, 56797, 65535}
+        set ANSI yellow color to {64507, 60395, 51400}
+        set ANSI blue color to {51657, 65535, 63479}
+        set ANSI magenta color to {56540, 50115, 63993}
+        set ANSI cyan color to {50629, 60909, 49601}
+        set ANSI white color to {63736, 60138, 59367}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {3855, 6168, 7710}
+        set ANSI bright red color to {65535, 54484, 59881}
+        set ANSI bright green color to {63479, 56797, 65535}
+        set ANSI bright yellow color to {64507, 60395, 51400}
+        set ANSI bright blue color to {51657, 65535, 63479}
+        set ANSI bright magenta color to {56540, 50115, 63993}
+        set ANSI bright cyan color to {50629, 60909, 49601}
+        set ANSI bright white color to {52428, 54227, 65278}
+    end tell
+end tell
+EOF

--- a/scripts/base16-sagelight.sh
+++ b/scripts/base16-sagelight.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63736, 63736, 63736}
+        set foreground color to {14392, 14392, 14392}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63736, 63736, 63736}
+        set ANSI red color to {64250, 33924, 32896}
+        set ANSI green color to {41120, 53970, 51400}
+        set ANSI yellow color to {65535, 56540, 24929}
+        set ANSI blue color to {41120, 42919, 53970}
+        set ANSI magenta color to {51400, 41120, 53970}
+        set ANSI cyan color to {41634, 54998, 62965}
+        set ANSI white color to {10280, 10280, 10280}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 55512, 55512}
+        set ANSI bright red color to {64250, 33924, 32896}
+        set ANSI bright green color to {41120, 53970, 51400}
+        set ANSI bright yellow color to {65535, 56540, 24929}
+        set ANSI bright blue color to {41120, 42919, 53970}
+        set ANSI bright magenta color to {51400, 41120, 53970}
+        set ANSI bright cyan color to {41634, 54998, 62965}
+        set ANSI bright white color to {6168, 6168, 6168}
+    end tell
+end tell
+EOF

--- a/scripts/base16-sakura.sh
+++ b/scripts/base16-sakura.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65278, 60909, 62451}
+        set foreground color to {22102, 17476, 18504}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65278, 60909, 62451}
+        set ANSI red color to {57311, 11565, 21074}
+        set ANSI green color to {11822, 37265, 28013}
+        set ANSI yellow color to {49858, 38036, 24929}
+        set ANSI blue color to {0, 28270, 37779}
+        set ANSI magenta color to {24158, 8481, 32896}
+        set ANSI cyan color to {7453, 35209, 37265}
+        set ANSI white color to {16962, 14392, 14906}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57568, 52428, 53713}
+        set ANSI bright red color to {57311, 11565, 21074}
+        set ANSI bright green color to {11822, 37265, 28013}
+        set ANSI bright yellow color to {49858, 38036, 24929}
+        set ANSI bright blue color to {0, 28270, 37779}
+        set ANSI bright magenta color to {24158, 8481, 32896}
+        set ANSI bright cyan color to {7453, 35209, 37265}
+        set ANSI bright white color to {13107, 10537, 11051}
+    end tell
+end tell
+EOF

--- a/scripts/base16-sandcastle.sh
+++ b/scripts/base16-sandcastle.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 11308, 13364}
+        set foreground color to {43176, 39321, 33924}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 11308, 13364}
+        set ANSI red color to {33667, 42405, 39064}
+        set ANSI green color to {21074, 35723, 35723}
+        set ANSI yellow color to {41120, 32382, 15163}
+        set ANSI blue color to {33667, 42405, 39064}
+        set ANSI magenta color to {55255, 24415, 24415}
+        set ANSI cyan color to {33667, 42405, 39064}
+        set ANSI white color to {54741, 50372, 41377}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15934, 17476, 20817}
+        set ANSI bright red color to {33667, 42405, 39064}
+        set ANSI bright green color to {21074, 35723, 35723}
+        set ANSI bright yellow color to {41120, 32382, 15163}
+        set ANSI bright blue color to {33667, 42405, 39064}
+        set ANSI bright magenta color to {55255, 24415, 24415}
+        set ANSI bright cyan color to {33667, 42405, 39064}
+        set ANSI bright white color to {65021, 62708, 49601}
+    end tell
+end tell
+EOF

--- a/scripts/base16-selenized-black.sh
+++ b/scripts/base16-selenized-black.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 6168, 6168}
+        set foreground color to {47545, 47545, 47545}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 6168, 6168}
+        set ANSI red color to {60909, 19018, 17990}
+        set ANSI green color to {28784, 46260, 13107}
+        set ANSI yellow color to {56283, 46003, 11565}
+        set ANSI blue color to {13878, 35466, 60395}
+        set ANSI magenta color to {42405, 32896, 58082}
+        set ANSI cyan color to {16191, 50629, 47031}
+        set ANSI white color to {57054, 57054, 57054}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15163, 15163, 15163}
+        set ANSI bright red color to {60909, 19018, 17990}
+        set ANSI bright green color to {28784, 46260, 13107}
+        set ANSI bright yellow color to {56283, 46003, 11565}
+        set ANSI bright blue color to {13878, 35466, 60395}
+        set ANSI bright magenta color to {42405, 32896, 58082}
+        set ANSI bright cyan color to {16191, 50629, 47031}
+        set ANSI bright white color to {57054, 57054, 57054}
+    end tell
+end tell
+EOF

--- a/scripts/base16-selenized-dark.sh
+++ b/scripts/base16-selenized-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 15420, 18504}
+        set foreground color to {44461, 48316, 48316}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 15420, 18504}
+        set ANSI red color to {64250, 22359, 20560}
+        set ANSI green color to {30069, 47545, 14392}
+        set ANSI yellow color to {56283, 46003, 11565}
+        set ANSI blue color to {17990, 38293, 63479}
+        set ANSI magenta color to {44975, 34952, 60395}
+        set ANSI cyan color to {16705, 51143, 47545}
+        set ANSI white color to {51914, 55512, 55769}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11565, 23387, 26985}
+        set ANSI bright red color to {64250, 22359, 20560}
+        set ANSI bright green color to {30069, 47545, 14392}
+        set ANSI bright yellow color to {56283, 46003, 11565}
+        set ANSI bright blue color to {17990, 38293, 63479}
+        set ANSI bright magenta color to {44975, 34952, 60395}
+        set ANSI bright cyan color to {16705, 51143, 47545}
+        set ANSI bright white color to {51914, 55512, 55769}
+    end tell
+end tell
+EOF

--- a/scripts/base16-selenized-light.sh
+++ b/scripts/base16-selenized-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 62451, 56283}
+        set foreground color to {21331, 26471, 28013}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 62451, 56283}
+        set ANSI red color to {52428, 5911, 10537}
+        set ANSI green color to {16962, 35723, 0}
+        set ANSI yellow color to {42919, 33667, 0}
+        set ANSI blue color to {0, 28013, 52942}
+        set ANSI magenta color to {33410, 23901, 49344}
+        set ANSI cyan color to {0, 38807, 35466}
+        set ANSI white color to {14906, 19789, 21331}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 52685, 46774}
+        set ANSI bright red color to {52428, 5911, 10537}
+        set ANSI bright green color to {16962, 35723, 0}
+        set ANSI bright yellow color to {42919, 33667, 0}
+        set ANSI bright blue color to {0, 28013, 52942}
+        set ANSI bright magenta color to {33410, 23901, 49344}
+        set ANSI bright cyan color to {0, 38807, 35466}
+        set ANSI bright white color to {14906, 19789, 21331}
+    end tell
+end tell
+EOF

--- a/scripts/base16-selenized-white.sh
+++ b/scripts/base16-selenized-white.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {18247, 18247, 18247}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {49087, 0, 0}
+        set ANSI green color to {0, 33924, 0}
+        set ANSI yellow color to {44975, 34181, 0}
+        set ANSI blue color to {0, 21588, 53199}
+        set ANSI magenta color to {27499, 16448, 50115}
+        set ANSI cyan color to {0, 39578, 35466}
+        set ANSI white color to {10280, 10280, 10280}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {52685, 52685, 52685}
+        set ANSI bright red color to {49087, 0, 0}
+        set ANSI bright green color to {0, 33924, 0}
+        set ANSI bright yellow color to {44975, 34181, 0}
+        set ANSI bright blue color to {0, 21588, 53199}
+        set ANSI bright magenta color to {27499, 16448, 50115}
+        set ANSI bright cyan color to {0, 39578, 35466}
+        set ANSI bright white color to {10280, 10280, 10280}
+    end tell
+end tell
+EOF

--- a/scripts/base16-seti.sh
+++ b/scripts/base16-seti.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5397, 5911, 6168}
+        set foreground color to {54998, 54998, 54998}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5397, 5911, 6168}
+        set ANSI red color to {52685, 16191, 17733}
+        set ANSI green color to {40863, 51914, 22102}
+        set ANSI yellow color to {59110, 52685, 26985}
+        set ANSI blue color to {21845, 46517, 56283}
+        set ANSI magenta color to {41120, 29812, 50372}
+        set ANSI cyan color to {21845, 56283, 48830}
+        set ANSI white color to {61166, 61166, 61166}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15163, 30069, 35980}
+        set ANSI bright red color to {52685, 16191, 17733}
+        set ANSI bright green color to {40863, 51914, 22102}
+        set ANSI bright yellow color to {59110, 52685, 26985}
+        set ANSI bright blue color to {21845, 46517, 56283}
+        set ANSI bright magenta color to {41120, 29812, 50372}
+        set ANSI bright cyan color to {21845, 56283, 48830}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-shades-of-purple.sh
+++ b/scripts/base16-shades-of-purple.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7710, 7710, 16191}
+        set foreground color to {51143, 51143, 51143}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7710, 7710, 16191}
+        set ANSI red color to {55769, 1028, 10537}
+        set ANSI green color to {14906, 55769, 0}
+        set ANSI yellow color to {65535, 59367, 0}
+        set ANSI blue color to {26985, 17219, 65535}
+        set ANSI magenta color to {65535, 11308, 28784}
+        set ANSI cyan color to {0, 50629, 51143}
+        set ANSI white color to {65535, 30583, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {61937, 53456, 0}
+        set ANSI bright red color to {55769, 1028, 10537}
+        set ANSI bright green color to {14906, 55769, 0}
+        set ANSI bright yellow color to {65535, 59367, 0}
+        set ANSI bright blue color to {26985, 17219, 65535}
+        set ANSI bright magenta color to {65535, 11308, 28784}
+        set ANSI bright cyan color to {0, 50629, 51143}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-shadesmear-dark.sh
+++ b/scripts/base16-shadesmear-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 8995, 8995}
+        set foreground color to {56283, 56283, 56283}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 8995, 8995}
+        set ANSI red color to {52428, 21588, 20560}
+        set ANSI green color to {29041, 39064, 15163}
+        set ANSI yellow color to {12336, 30840, 30840}
+        set ANSI blue color to {14135, 25443, 34952}
+        set ANSI magenta color to {55255, 43947, 21588}
+        set ANSI cyan color to {50629, 32125, 16962}
+        set ANSI white color to {58596, 58596, 58596}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20046, 20046, 20046}
+        set ANSI bright red color to {52428, 21588, 20560}
+        set ANSI bright green color to {29041, 39064, 15163}
+        set ANSI bright yellow color to {12336, 30840, 30840}
+        set ANSI bright blue color to {14135, 25443, 34952}
+        set ANSI bright magenta color to {55255, 43947, 21588}
+        set ANSI bright cyan color to {50629, 32125, 16962}
+        set ANSI bright white color to {7196, 7196, 7196}
+    end tell
+end tell
+EOF

--- a/scripts/base16-shadesmear-light.sh
+++ b/scripts/base16-shadesmear-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {56283, 56283, 56283}
+        set foreground color to {8995, 8995, 8995}
+
+        -- Set ANSI Colors
+        set ANSI black color to {56283, 56283, 56283}
+        set ANSI red color to {52428, 21588, 20560}
+        set ANSI green color to {29041, 39064, 15163}
+        set ANSI yellow color to {12336, 30840, 30840}
+        set ANSI blue color to {14135, 25443, 34952}
+        set ANSI magenta color to {55255, 43947, 21588}
+        set ANSI cyan color to {50629, 32125, 16962}
+        set ANSI white color to {7196, 7196, 7196}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {49344, 49344, 49344}
+        set ANSI bright red color to {52428, 21588, 20560}
+        set ANSI bright green color to {29041, 39064, 15163}
+        set ANSI bright yellow color to {12336, 30840, 30840}
+        set ANSI bright blue color to {14135, 25443, 34952}
+        set ANSI bright magenta color to {55255, 43947, 21588}
+        set ANSI bright cyan color to {50629, 32125, 16962}
+        set ANSI bright white color to {58596, 58596, 58596}
+    end tell
+end tell
+EOF

--- a/scripts/base16-shapeshifter.sh
+++ b/scripts/base16-shapeshifter.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {63993, 63993, 63993}
+        set foreground color to {4112, 8224, 5397}
+
+        -- Set ANSI Colors
+        set ANSI black color to {63993, 63993, 63993}
+        set ANSI red color to {59881, 12079, 12079}
+        set ANSI green color to {3598, 55512, 14649}
+        set ANSI yellow color to {56797, 56797, 4883}
+        set ANSI blue color to {15163, 18504, 58339}
+        set ANSI magenta color to {63993, 38550, 58082}
+        set ANSI cyan color to {8995, 60909, 56026}
+        set ANSI white color to {1028, 1028, 1028}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {43947, 43947, 43947}
+        set ANSI bright red color to {59881, 12079, 12079}
+        set ANSI bright green color to {3598, 55512, 14649}
+        set ANSI bright yellow color to {56797, 56797, 4883}
+        set ANSI bright blue color to {15163, 18504, 58339}
+        set ANSI bright magenta color to {63993, 38550, 58082}
+        set ANSI bright cyan color to {8995, 60909, 56026}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-silk-dark.sh
+++ b/scripts/base16-silk-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3598, 15420, 17990}
+        set foreground color to {51143, 56283, 56797}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3598, 15420, 17990}
+        set ANSI red color to {64507, 26985, 21331}
+        set ANSI green color to {29555, 55512, 44461}
+        set ANSI yellow color to {64764, 58339, 32896}
+        set ANSI blue color to {17990, 48573, 56797}
+        set ANSI magenta color to {30069, 27499, 35466}
+        set ANSI cyan color to {16191, 45746, 47545}
+        set ANSI white color to {52171, 62194, 63479}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10794, 20560, 21588}
+        set ANSI bright red color to {64507, 26985, 21331}
+        set ANSI bright green color to {29555, 55512, 44461}
+        set ANSI bright yellow color to {64764, 58339, 32896}
+        set ANSI bright blue color to {17990, 48573, 56797}
+        set ANSI bright magenta color to {30069, 27499, 35466}
+        set ANSI bright cyan color to {16191, 45746, 47545}
+        set ANSI bright white color to {53970, 64250, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-silk-light.sh
+++ b/scripts/base16-silk-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {59881, 61937, 61423}
+        set foreground color to {14392, 20817, 22102}
+
+        -- Set ANSI Colors
+        set ANSI black color to {59881, 61937, 61423}
+        set ANSI red color to {53199, 17219, 11822}
+        set ANSI green color to {27756, 41891, 35980}
+        set ANSI yellow color to {53199, 44461, 9509}
+        set ANSI blue color to {14649, 43690, 51657}
+        set ANSI magenta color to {28270, 25957, 33410}
+        set ANSI cyan color to {12850, 40092, 41634}
+        set ANSI white color to {3598, 15420, 17990}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {37008, 47031, 46774}
+        set ANSI bright red color to {53199, 17219, 11822}
+        set ANSI bright green color to {27756, 41891, 35980}
+        set ANSI bright yellow color to {53199, 44461, 9509}
+        set ANSI bright blue color to {14649, 43690, 51657}
+        set ANSI bright magenta color to {28270, 25957, 33410}
+        set ANSI bright cyan color to {12850, 40092, 41634}
+        set ANSI bright white color to {53970, 64250, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-snazzy.sh
+++ b/scripts/base16-snazzy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 10794, 13878}
+        set foreground color to {58082, 58596, 58853}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 10794, 13878}
+        set ANSI red color to {65535, 23644, 22359}
+        set ANSI green color to {23130, 63479, 36494}
+        set ANSI yellow color to {62451, 63993, 40349}
+        set ANSI blue color to {22359, 51143, 65535}
+        set ANSI magenta color to {65535, 27242, 49601}
+        set ANSI cyan color to {39578, 60909, 65278}
+        set ANSI white color to {61423, 61680, 60395}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17219, 17733, 20303}
+        set ANSI bright red color to {65535, 23644, 22359}
+        set ANSI bright green color to {23130, 63479, 36494}
+        set ANSI bright yellow color to {62451, 63993, 40349}
+        set ANSI bright blue color to {22359, 51143, 65535}
+        set ANSI bright magenta color to {65535, 27242, 49601}
+        set ANSI bright cyan color to {39578, 60909, 65278}
+        set ANSI bright white color to {61937, 61937, 61680}
+    end tell
+end tell
+EOF

--- a/scripts/base16-solarflare-light.sh
+++ b/scripts/base16-solarflare-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62965, 63479, 64250}
+        set foreground color to {22616, 26728, 30069}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62965, 63479, 64250}
+        set ANSI red color to {61423, 21074, 21331}
+        set ANSI green color to {31868, 51400, 17476}
+        set ANSI yellow color to {58596, 46517, 7196}
+        set ANSI blue color to {13107, 46517, 57825}
+        set ANSI magenta color to {41891, 25443, 54741}
+        set ANSI cyan color to {21074, 52171, 45232}
+        set ANSI white color to {8738, 11822, 14392}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {42662, 44975, 47288}
+        set ANSI bright red color to {61423, 21074, 21331}
+        set ANSI bright green color to {31868, 51400, 17476}
+        set ANSI bright yellow color to {58596, 46517, 7196}
+        set ANSI bright blue color to {13107, 46517, 57825}
+        set ANSI bright magenta color to {41891, 25443, 54741}
+        set ANSI bright cyan color to {21074, 52171, 45232}
+        set ANSI bright white color to {6168, 9766, 12079}
+    end tell
+end tell
+EOF

--- a/scripts/base16-solarflare.sh
+++ b/scripts/base16-solarflare.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6168, 9766, 12079}
+        set foreground color to {42662, 44975, 47288}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6168, 9766, 12079}
+        set ANSI red color to {61423, 21074, 21331}
+        set ANSI green color to {31868, 51400, 17476}
+        set ANSI yellow color to {58596, 46517, 7196}
+        set ANSI blue color to {13107, 46517, 57825}
+        set ANSI magenta color to {41891, 25443, 54741}
+        set ANSI cyan color to {21074, 52171, 45232}
+        set ANSI white color to {59624, 59881, 60909}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 26728, 30069}
+        set ANSI bright red color to {61423, 21074, 21331}
+        set ANSI bright green color to {31868, 51400, 17476}
+        set ANSI bright yellow color to {58596, 46517, 7196}
+        set ANSI bright blue color to {13107, 46517, 57825}
+        set ANSI bright magenta color to {41891, 25443, 54741}
+        set ANSI bright cyan color to {21074, 52171, 45232}
+        set ANSI bright white color to {62965, 63479, 64250}
+    end tell
+end tell
+EOF

--- a/scripts/base16-solarized-dark.sh
+++ b/scripts/base16-solarized-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 11051, 13878}
+        set foreground color to {37779, 41377, 41377}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 11051, 13878}
+        set ANSI red color to {56540, 12850, 12079}
+        set ANSI green color to {34181, 39321, 0}
+        set ANSI yellow color to {46517, 35209, 0}
+        set ANSI blue color to {9766, 35723, 53970}
+        set ANSI magenta color to {27756, 29041, 50372}
+        set ANSI cyan color to {10794, 41377, 39064}
+        set ANSI white color to {61166, 59624, 54741}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {22616, 28270, 30069}
+        set ANSI bright red color to {56540, 12850, 12079}
+        set ANSI bright green color to {34181, 39321, 0}
+        set ANSI bright yellow color to {46517, 35209, 0}
+        set ANSI bright blue color to {9766, 35723, 53970}
+        set ANSI bright magenta color to {27756, 29041, 50372}
+        set ANSI bright cyan color to {10794, 41377, 39064}
+        set ANSI bright white color to {65021, 63222, 58339}
+    end tell
+end tell
+EOF

--- a/scripts/base16-solarized-light.sh
+++ b/scripts/base16-solarized-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65021, 63222, 58339}
+        set foreground color to {22616, 28270, 30069}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65021, 63222, 58339}
+        set ANSI red color to {56540, 12850, 12079}
+        set ANSI green color to {34181, 39321, 0}
+        set ANSI yellow color to {46517, 35209, 0}
+        set ANSI blue color to {9766, 35723, 53970}
+        set ANSI magenta color to {27756, 29041, 50372}
+        set ANSI cyan color to {10794, 41377, 39064}
+        set ANSI white color to {1799, 13878, 16962}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {37779, 41377, 41377}
+        set ANSI bright red color to {56540, 12850, 12079}
+        set ANSI bright green color to {34181, 39321, 0}
+        set ANSI bright yellow color to {46517, 35209, 0}
+        set ANSI bright blue color to {9766, 35723, 53970}
+        set ANSI bright magenta color to {27756, 29041, 50372}
+        set ANSI bright cyan color to {10794, 41377, 39064}
+        set ANSI bright white color to {0, 11051, 13878}
+    end tell
+end tell
+EOF

--- a/scripts/base16-spaceduck.sh
+++ b/scripts/base16-spaceduck.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5654, 5911, 11565}
+        set foreground color to {60652, 61680, 49601}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5654, 5911, 11565}
+        set ANSI red color to {58339, 13364, 0}
+        set ANSI green color to {23644, 52428, 38550}
+        set ANSI yellow color to {62194, 52942, 0}
+        set ANSI blue color to {31354, 23644, 52428}
+        set ANSI magenta color to {46003, 41377, 59110}
+        set ANSI cyan color to {0, 41891, 52428}
+        set ANSI white color to {49601, 50115, 52428}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 13878, 24415}
+        set ANSI bright red color to {58339, 13364, 0}
+        set ANSI bright green color to {23644, 52428, 38550}
+        set ANSI bright yellow color to {62194, 52942, 0}
+        set ANSI bright blue color to {31354, 23644, 52428}
+        set ANSI bright magenta color to {46003, 41377, 59110}
+        set ANSI bright cyan color to {0, 41891, 52428}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-spacemacs.sh
+++ b/scripts/base16-spacemacs.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7967, 8224, 8738}
+        set foreground color to {41891, 41891, 41891}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7967, 8224, 8738}
+        set ANSI red color to {62194, 9252, 7967}
+        set ANSI green color to {26471, 45489, 7453}
+        set ANSI yellow color to {45489, 38293, 7453}
+        set ANSI blue color to {20303, 38807, 55255}
+        set ANSI magenta color to {41891, 7453, 45489}
+        set ANSI cyan color to {11565, 38293, 29812}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17476, 16705, 21845}
+        set ANSI bright red color to {62194, 9252, 7967}
+        set ANSI bright green color to {26471, 45489, 7453}
+        set ANSI bright yellow color to {45489, 38293, 7453}
+        set ANSI bright blue color to {20303, 38807, 55255}
+        set ANSI bright magenta color to {41891, 7453, 45489}
+        set ANSI bright cyan color to {11565, 38293, 29812}
+        set ANSI bright white color to {63736, 63736, 63736}
+    end tell
+end tell
+EOF

--- a/scripts/base16-sparky.sh
+++ b/scripts/base16-sparky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1799, 11051, 12593}
+        set foreground color to {62708, 62965, 61680}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1799, 11051, 12593}
+        set ANSI red color to {65535, 22616, 23901}
+        set ANSI green color to {30840, 54998, 19275}
+        set ANSI yellow color to {64507, 56797, 16448}
+        set ANSI blue color to {17990, 39064, 52171}
+        set ANSI magenta color to {54741, 40606, 55255}
+        set ANSI cyan color to {11565, 52428, 54227}
+        set ANSI white color to {62965, 62965, 61937}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 15420, 17990}
+        set ANSI bright red color to {65535, 22616, 23901}
+        set ANSI bright green color to {30840, 54998, 19275}
+        set ANSI bright yellow color to {64507, 56797, 16448}
+        set ANSI bright blue color to {17990, 39064, 52171}
+        set ANSI bright magenta color to {54741, 40606, 55255}
+        set ANSI bright cyan color to {11565, 52428, 54227}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-standardized-dark.sh
+++ b/scripts/base16-standardized-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 8738, 8738}
+        set foreground color to {49344, 49344, 49344}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 8738, 8738}
+        set ANSI red color to {57825, 23901, 26471}
+        set ANSI green color to {23901, 45489, 10537}
+        set ANSI yellow color to {57825, 46003, 6682}
+        set ANSI blue color to {0, 41891, 62194}
+        set ANSI magenta color to {46260, 28270, 57568}
+        set ANSI cyan color to {8481, 51657, 37522}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21845, 21845, 21845}
+        set ANSI bright red color to {57825, 23901, 26471}
+        set ANSI bright green color to {23901, 45489, 10537}
+        set ANSI bright yellow color to {57825, 46003, 6682}
+        set ANSI bright blue color to {0, 41891, 62194}
+        set ANSI bright magenta color to {46260, 28270, 57568}
+        set ANSI bright cyan color to {8481, 51657, 37522}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-standardized-light.sh
+++ b/scripts/base16-standardized-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {17476, 17476, 17476}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {53456, 15934, 15934}
+        set ANSI green color to {12593, 34438, 7967}
+        set ANSI yellow color to {44461, 33410, 0}
+        set ANSI blue color to {12593, 29555, 50629}
+        set ANSI magenta color to {40606, 22359, 49858}
+        set ANSI cyan color to {0, 39321, 36751}
+        set ANSI white color to {13107, 13107, 13107}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {52428, 52428, 52428}
+        set ANSI bright red color to {53456, 15934, 15934}
+        set ANSI bright green color to {12593, 34438, 7967}
+        set ANSI bright yellow color to {44461, 33410, 0}
+        set ANSI bright blue color to {12593, 29555, 50629}
+        set ANSI bright magenta color to {40606, 22359, 49858}
+        set ANSI bright cyan color to {0, 39321, 36751}
+        set ANSI bright white color to {8738, 8738, 8738}
+    end tell
+end tell
+EOF

--- a/scripts/base16-stella.sh
+++ b/scripts/base16-stella.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11051, 8481, 15420}
+        set foreground color to {39321, 35723, 44461}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11051, 8481, 15420}
+        set ANSI red color to {51143, 39321, 34695}
+        set ANSI green color to {44204, 51143, 39835}
+        set ANSI yellow color to {51143, 50886, 37265}
+        set ANSI blue color to {42405, 43690, 54484}
+        set ANSI magenta color to {50629, 38036, 65535}
+        set ANSI cyan color to {39835, 51143, 49087}
+        set ANSI white color to {46260, 42405, 51400}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19789, 16705, 24672}
+        set ANSI bright red color to {51143, 39321, 34695}
+        set ANSI bright green color to {44204, 51143, 39835}
+        set ANSI bright yellow color to {51143, 50886, 37265}
+        set ANSI bright blue color to {42405, 43690, 54484}
+        set ANSI bright magenta color to {50629, 38036, 65535}
+        set ANSI bright cyan color to {39835, 51143, 49087}
+        set ANSI bright white color to {60395, 56540, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-still-alive.sh
+++ b/scripts/base16-still-alive.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61680, 61680, 61680}
+        set foreground color to {55512, 0, 0}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61680, 61680, 61680}
+        set ANSI red color to {18504, 30840, 12336}
+        set ANSI green color to {23644, 23644, 27242}
+        set ANSI yellow color to {16962, 25443, 38293}
+        set ANSI blue color to {0, 6168, 30840}
+        set ANSI magenta color to {37008, 0, 0}
+        set ANSI cyan color to {11308, 15420, 22359}
+        set ANSI white color to {18504, 37008, 0}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {65535, 61680, 6168}
+        set ANSI bright red color to {18504, 30840, 12336}
+        set ANSI bright green color to {23644, 23644, 27242}
+        set ANSI bright yellow color to {16962, 25443, 38293}
+        set ANSI bright blue color to {0, 6168, 30840}
+        set ANSI bright magenta color to {37008, 0, 0}
+        set ANSI bright cyan color to {11308, 15420, 22359}
+        set ANSI bright white color to {12336, 43176, 24672}
+    end tell
+end tell
+EOF

--- a/scripts/base16-summercamp.sh
+++ b/scripts/base16-summercamp.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7196, 6168, 4112}
+        set foreground color to {29555, 28270, 21845}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7196, 6168, 4112}
+        set ANSI red color to {58339, 20817, 16962}
+        set ANSI green color to {23644, 60395, 23130}
+        set ANSI yellow color to {62194, 65535, 10023}
+        set ANSI blue color to {18504, 39835, 61680}
+        set ANSI magenta color to {65535, 32896, 32896}
+        set ANSI cyan color to {23130, 60395, 48316}
+        set ANSI white color to {47802, 46774, 38550}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14906, 13621, 10023}
+        set ANSI bright red color to {58339, 20817, 16962}
+        set ANSI bright green color to {23644, 60395, 23130}
+        set ANSI bright yellow color to {62194, 65535, 10023}
+        set ANSI bright blue color to {18504, 39835, 61680}
+        set ANSI bright magenta color to {65535, 32896, 32896}
+        set ANSI bright cyan color to {23130, 60395, 48316}
+        set ANSI bright white color to {63736, 62965, 57054}
+    end tell
+end tell
+EOF

--- a/scripts/base16-summerfruit-dark.sh
+++ b/scripts/base16-summerfruit-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5397, 5397, 5397}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5397, 5397, 5397}
+        set ANSI red color to {65535, 0, 34438}
+        set ANSI green color to {0, 51657, 6168}
+        set ANSI yellow color to {43947, 43176, 0}
+        set ANSI blue color to {14135, 30583, 59110}
+        set ANSI magenta color to {44461, 0, 41377}
+        set ANSI cyan color to {7967, 43690, 43690}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {65535, 0, 34438}
+        set ANSI bright green color to {0, 51657, 6168}
+        set ANSI bright yellow color to {43947, 43176, 0}
+        set ANSI bright blue color to {14135, 30583, 59110}
+        set ANSI bright magenta color to {44461, 0, 41377}
+        set ANSI bright cyan color to {7967, 43690, 43690}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-summerfruit-light.sh
+++ b/scripts/base16-summerfruit-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {4112, 4112, 4112}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {65535, 0, 34438}
+        set ANSI green color to {0, 51657, 6168}
+        set ANSI yellow color to {43947, 43176, 0}
+        set ANSI blue color to {14135, 30583, 59110}
+        set ANSI magenta color to {44461, 0, 41377}
+        set ANSI cyan color to {7967, 43690, 43690}
+        set ANSI white color to {5397, 5397, 5397}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {53456, 53456, 53456}
+        set ANSI bright red color to {65535, 0, 34438}
+        set ANSI bright green color to {0, 51657, 6168}
+        set ANSI bright yellow color to {43947, 43176, 0}
+        set ANSI bright blue color to {14135, 30583, 59110}
+        set ANSI bright magenta color to {44461, 0, 41377}
+        set ANSI bright cyan color to {7967, 43690, 43690}
+        set ANSI bright white color to {8224, 8224, 8224}
+    end tell
+end tell
+EOF

--- a/scripts/base16-synth-midnight-dark.sh
+++ b/scripts/base16-synth-midnight-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1285, 1542, 2056}
+        set foreground color to {49601, 50115, 50372}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1285, 1542, 2056}
+        set ANSI red color to {46517, 15163, 20560}
+        set ANSI green color to {1542, 60138, 24929}
+        set ANSI yellow color to {51657, 54227, 25700}
+        set ANSI blue color to {771, 44718, 65535}
+        set ANSI magenta color to {60138, 23644, 58082}
+        set ANSI cyan color to {16962, 65535, 63993}
+        set ANSI white color to {53199, 53713, 53970}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10280, 10537, 10794}
+        set ANSI bright red color to {46517, 15163, 20560}
+        set ANSI bright green color to {1542, 60138, 24929}
+        set ANSI bright yellow color to {51657, 54227, 25700}
+        set ANSI bright blue color to {771, 44718, 65535}
+        set ANSI bright magenta color to {60138, 23644, 58082}
+        set ANSI bright cyan color to {16962, 65535, 63993}
+        set ANSI bright white color to {56797, 57311, 57568}
+    end tell
+end tell
+EOF

--- a/scripts/base16-synth-midnight-light.sh
+++ b/scripts/base16-synth-midnight-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {56797, 57311, 57568}
+        set foreground color to {10280, 10537, 10794}
+
+        -- Set ANSI Colors
+        set ANSI black color to {56797, 57311, 57568}
+        set ANSI red color to {46517, 15163, 20560}
+        set ANSI green color to {1542, 60138, 24929}
+        set ANSI yellow color to {51657, 54227, 25700}
+        set ANSI blue color to {771, 44718, 65535}
+        set ANSI magenta color to {60138, 23644, 58082}
+        set ANSI cyan color to {16962, 65535, 63993}
+        set ANSI white color to {6682, 6939, 7196}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {49601, 50115, 50372}
+        set ANSI bright red color to {46517, 15163, 20560}
+        set ANSI bright green color to {1542, 60138, 24929}
+        set ANSI bright yellow color to {51657, 54227, 25700}
+        set ANSI bright blue color to {771, 44718, 65535}
+        set ANSI bright magenta color to {60138, 23644, 58082}
+        set ANSI bright cyan color to {16962, 65535, 63993}
+        set ANSI bright white color to {1285, 1542, 2056}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tango.sh
+++ b/scripts/base16-tango.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11822, 13364, 13878}
+        set foreground color to {54227, 55255, 53199}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11822, 13364, 13878}
+        set ANSI red color to {52428, 0, 0}
+        set ANSI green color to {20046, 39578, 1542}
+        set ANSI yellow color to {50372, 41120, 0}
+        set ANSI blue color to {13364, 25957, 42148}
+        set ANSI magenta color to {30069, 20560, 31611}
+        set ANSI cyan color to {1542, 39064, 39578}
+        set ANSI white color to {44461, 32639, 43176}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {64764, 59881, 20303}
+        set ANSI bright red color to {52428, 0, 0}
+        set ANSI bright green color to {20046, 39578, 1542}
+        set ANSI bright yellow color to {50372, 41120, 0}
+        set ANSI bright blue color to {13364, 25957, 42148}
+        set ANSI bright magenta color to {30069, 20560, 31611}
+        set ANSI bright cyan color to {1542, 39064, 39578}
+        set ANSI bright white color to {61166, 61166, 60652}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tarot.sh
+++ b/scripts/base16-tarot.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3598, 2313, 7453}
+        set foreground color to {43690, 21845, 28527}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3598, 2313, 7453}
+        set ANSI red color to {50629, 12850, 21331}
+        set ANSI green color to {42662, 36494, 23130}
+        set ANSI yellow color to {65535, 25957, 25957}
+        set ANSI blue color to {28270, 24672, 32896}
+        set ANSI magenta color to {42148, 22359, 33410}
+        set ANSI cyan color to {35980, 38807, 34181}
+        set ANSI white color to {50372, 26728, 28013}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {19275, 8224, 21588}
+        set ANSI bright red color to {50629, 12850, 21331}
+        set ANSI bright green color to {42662, 36494, 23130}
+        set ANSI bright yellow color to {65535, 25957, 25957}
+        set ANSI bright blue color to {28270, 24672, 32896}
+        set ANSI bright magenta color to {42148, 22359, 33410}
+        set ANSI bright cyan color to {35980, 38807, 34181}
+        set ANSI bright white color to {56540, 36751, 31868}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tender.sh
+++ b/scripts/base16-tender.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 10280, 10280}
+        set foreground color to {61166, 61166, 61166}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 10280, 10280}
+        set ANSI red color to {62708, 14135, 21331}
+        set ANSI green color to {51657, 53456, 23644}
+        set ANSI yellow color to {65535, 49858, 19275}
+        set ANSI blue color to {46003, 57054, 61423}
+        set ANSI magenta color to {54227, 47545, 34695}
+        set ANSI cyan color to {29555, 52942, 62708}
+        set ANSI white color to {59624, 59624, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18504, 18504, 18504}
+        set ANSI bright red color to {62708, 14135, 21331}
+        set ANSI bright green color to {51657, 53456, 23644}
+        set ANSI bright yellow color to {65535, 49858, 19275}
+        set ANSI bright blue color to {46003, 57054, 61423}
+        set ANSI bright magenta color to {54227, 47545, 34695}
+        set ANSI bright cyan color to {29555, 52942, 62708}
+        set ANSI bright white color to {65278, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-terracotta-dark.sh
+++ b/scripts/base16-terracotta-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9252, 7453, 6682}
+        set foreground color to {47288, 42405, 40349}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9252, 7453, 6682}
+        set ANSI red color to {63222, 39321, 36751}
+        set ANSI green color to {46774, 50886, 35466}
+        set ANSI yellow color to {65535, 50115, 31354}
+        set ANSI blue color to {45232, 42148, 50115}
+        set ANSI magenta color to {55512, 41634, 45232}
+        set ANSI cyan color to {49344, 48316, 56283}
+        set ANSI white color to {51914, 48059, 46517}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18247, 14649, 13107}
+        set ANSI bright red color to {63222, 39321, 36751}
+        set ANSI bright green color to {46774, 50886, 35466}
+        set ANSI bright yellow color to {65535, 50115, 31354}
+        set ANSI bright blue color to {45232, 42148, 50115}
+        set ANSI bright magenta color to {55512, 41634, 45232}
+        set ANSI bright cyan color to {49344, 48316, 56283}
+        set ANSI bright white color to {56540, 53970, 52942}
+    end tell
+end tell
+EOF

--- a/scripts/base16-terracotta.sh
+++ b/scripts/base16-terracotta.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {61423, 60138, 59624}
+        set foreground color to {18247, 14135, 12593}
+
+        -- Set ANSI Colors
+        set ANSI black color to {61423, 60138, 59624}
+        set ANSI red color to {42919, 20560, 17733}
+        set ANSI green color to {31354, 35209, 19018}
+        set ANSI yellow color to {52942, 38036, 15934}
+        set ANSI blue color to {25186, 21845, 29812}
+        set ANSI magenta color to {36237, 22873, 26728}
+        set ANSI cyan color to {33924, 32639, 40606}
+        set ANSI white color to {13621, 10794, 9509}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {53456, 49601, 48059}
+        set ANSI bright red color to {42919, 20560, 17733}
+        set ANSI bright green color to {31354, 35209, 19018}
+        set ANSI bright yellow color to {52942, 38036, 15934}
+        set ANSI bright blue color to {25186, 21845, 29812}
+        set ANSI bright magenta color to {36237, 22873, 26728}
+        set ANSI bright cyan color to {33924, 32639, 40606}
+        set ANSI bright white color to {9252, 7196, 6425}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-city-dark.sh
+++ b/scripts/base16-tokyo-city-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 7453, 8995}
+        set foreground color to {55512, 58082, 60652}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 7453, 8995}
+        set ANSI red color to {63479, 30326, 36494}
+        set ANSI green color to {40606, 52942, 27242}
+        set ANSI yellow color to {47031, 50629, 54227}
+        set ANSI blue color to {31354, 41634, 63479}
+        set ANSI magenta color to {48059, 39578, 63479}
+        set ANSI cyan color to {35209, 56797, 65535}
+        set ANSI white color to {63222, 63222, 63736}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10280, 12850, 14906}
+        set ANSI bright red color to {63479, 30326, 36494}
+        set ANSI bright green color to {40606, 52942, 27242}
+        set ANSI bright yellow color to {47031, 50629, 54227}
+        set ANSI bright blue color to {31354, 41634, 63479}
+        set ANSI bright magenta color to {48059, 39578, 63479}
+        set ANSI bright cyan color to {35209, 56797, 65535}
+        set ANSI bright white color to {64507, 64507, 65021}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-city-light.sh
+++ b/scripts/base16-tokyo-city-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 64507, 65021}
+        set foreground color to {13364, 15163, 22873}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 64507, 65021}
+        set ANSI red color to {35980, 17219, 20817}
+        set ANSI green color to {18504, 24158, 12336}
+        set ANSI yellow color to {19532, 20560, 24158}
+        set ANSI blue color to {13364, 21588, 35466}
+        set ANSI magenta color to {23130, 19018, 30840}
+        set ANSI cyan color to {19532, 20560, 24158}
+        set ANSI white color to {7453, 9509, 11308}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {60909, 61423, 63222}
+        set ANSI bright red color to {35980, 17219, 20817}
+        set ANSI bright green color to {18504, 24158, 12336}
+        set ANSI bright yellow color to {19532, 20560, 24158}
+        set ANSI bright blue color to {13364, 21588, 35466}
+        set ANSI bright magenta color to {23130, 19018, 30840}
+        set ANSI bright cyan color to {19532, 20560, 24158}
+        set ANSI bright white color to {5911, 7453, 8995}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-city-terminal-dark.sh
+++ b/scripts/base16-tokyo-city-terminal-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 7453, 8995}
+        set foreground color to {55512, 58082, 60652}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 7453, 8995}
+        set ANSI red color to {55769, 21588, 26728}
+        set ANSI green color to {35723, 54484, 40092}
+        set ANSI yellow color to {60395, 49087, 33667}
+        set ANSI blue color to {21331, 39578, 64764}
+        set ANSI magenta color to {46774, 11565, 25957}
+        set ANSI cyan color to {28784, 57825, 59624}
+        set ANSI white color to {63222, 63222, 63736}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10280, 12850, 14906}
+        set ANSI bright red color to {55769, 21588, 26728}
+        set ANSI bright green color to {35723, 54484, 40092}
+        set ANSI bright yellow color to {60395, 49087, 33667}
+        set ANSI bright blue color to {21331, 39578, 64764}
+        set ANSI bright magenta color to {46774, 11565, 25957}
+        set ANSI bright cyan color to {28784, 57825, 59624}
+        set ANSI bright white color to {64507, 64507, 65021}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-city-terminal-light.sh
+++ b/scripts/base16-tokyo-city-terminal-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64507, 64507, 65021}
+        set foreground color to {10280, 12850, 14906}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64507, 64507, 65021}
+        set ANSI red color to {35980, 17219, 20817}
+        set ANSI green color to {13107, 25443, 23644}
+        set ANSI yellow color to {36751, 24158, 5397}
+        set ANSI blue color to {13364, 21588, 35466}
+        set ANSI magenta color to {23130, 19018, 30840}
+        set ANSI cyan color to {3855, 19275, 28270}
+        set ANSI white color to {7453, 9509, 11308}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55512, 58082, 60652}
+        set ANSI bright red color to {35980, 17219, 20817}
+        set ANSI bright green color to {13107, 25443, 23644}
+        set ANSI bright yellow color to {36751, 24158, 5397}
+        set ANSI bright blue color to {13364, 21588, 35466}
+        set ANSI bright magenta color to {23130, 19018, 30840}
+        set ANSI bright cyan color to {3855, 19275, 28270}
+        set ANSI bright white color to {5911, 7453, 8995}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-dark.sh
+++ b/scripts/base16-tokyo-night-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6682, 6939, 9766}
+        set foreground color to {43433, 45489, 54998}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6682, 6939, 9766}
+        set ANSI red color to {49344, 51914, 62965}
+        set ANSI green color to {40606, 52942, 27242}
+        set ANSI yellow color to {3341, 47545, 55255}
+        set ANSI blue color to {10794, 50115, 57054}
+        set ANSI magenta color to {48059, 39578, 63479}
+        set ANSI cyan color to {46260, 63993, 63736}
+        set ANSI white color to {52171, 52428, 53713}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12079, 13621, 18761}
+        set ANSI bright red color to {49344, 51914, 62965}
+        set ANSI bright green color to {40606, 52942, 27242}
+        set ANSI bright yellow color to {3341, 47545, 55255}
+        set ANSI bright blue color to {10794, 50115, 57054}
+        set ANSI bright magenta color to {48059, 39578, 63479}
+        set ANSI bright cyan color to {46260, 63993, 63736}
+        set ANSI bright white color to {54741, 54998, 56283}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-light.sh
+++ b/scripts/base16-tokyo-night-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {54741, 54998, 56283}
+        set foreground color to {13364, 15163, 22873}
+
+        -- Set ANSI Colors
+        set ANSI black color to {54741, 54998, 56283}
+        set ANSI red color to {13364, 15163, 22616}
+        set ANSI green color to {18504, 24158, 12336}
+        set ANSI yellow color to {5654, 26471, 30069}
+        set ANSI blue color to {13364, 21588, 35466}
+        set ANSI magenta color to {23130, 19018, 30840}
+        set ANSI cyan color to {15934, 26985, 26728}
+        set ANSI white color to {6682, 6939, 9766}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57311, 57568, 58853}
+        set ANSI bright red color to {13364, 15163, 22616}
+        set ANSI bright green color to {18504, 24158, 12336}
+        set ANSI bright yellow color to {5654, 26471, 30069}
+        set ANSI bright blue color to {13364, 21588, 35466}
+        set ANSI bright magenta color to {23130, 19018, 30840}
+        set ANSI bright cyan color to {15934, 26985, 26728}
+        set ANSI bright white color to {6682, 6939, 9766}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-moon.sh
+++ b/scripts/base16-tokyo-night-moon.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8738, 9252, 13878}
+        set foreground color to {15163, 16962, 24929}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8738, 9252, 13878}
+        set ANSI red color to {65535, 30069, 32639}
+        set ANSI green color to {50115, 59624, 36237}
+        set ANSI yellow color to {65535, 51143, 30583}
+        set ANSI blue color to {33410, 43690, 65535}
+        set ANSI magenta color to {64764, 42919, 60138}
+        set ANSI cyan color to {34438, 57825, 64764}
+        set ANSI white color to {33410, 35723, 47288}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11565, 16191, 30326}
+        set ANSI bright red color to {65535, 30069, 32639}
+        set ANSI bright green color to {50115, 59624, 36237}
+        set ANSI bright yellow color to {65535, 51143, 30583}
+        set ANSI bright blue color to {33410, 43690, 65535}
+        set ANSI bright magenta color to {64764, 42919, 60138}
+        set ANSI bright cyan color to {34438, 57825, 64764}
+        set ANSI bright white color to {51400, 54227, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-storm.sh
+++ b/scripts/base16-tokyo-night-storm.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9252, 10280, 15163}
+        set foreground color to {43433, 45489, 54998}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9252, 10280, 15163}
+        set ANSI red color to {49344, 51914, 62965}
+        set ANSI green color to {40606, 52942, 27242}
+        set ANSI yellow color to {3341, 47545, 55255}
+        set ANSI blue color to {10794, 50115, 57054}
+        set ANSI magenta color to {48059, 39578, 63479}
+        set ANSI cyan color to {46260, 63993, 63736}
+        set ANSI white color to {52171, 52428, 53713}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13364, 14906, 21074}
+        set ANSI bright red color to {49344, 51914, 62965}
+        set ANSI bright green color to {40606, 52942, 27242}
+        set ANSI bright yellow color to {3341, 47545, 55255}
+        set ANSI bright blue color to {10794, 50115, 57054}
+        set ANSI bright magenta color to {48059, 39578, 63479}
+        set ANSI bright cyan color to {46260, 63993, 63736}
+        set ANSI bright white color to {54741, 54998, 56283}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-terminal-dark.sh
+++ b/scripts/base16-tokyo-night-terminal-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5654, 5654, 7710}
+        set foreground color to {30840, 31868, 39321}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5654, 5654, 7710}
+        set ANSI red color to {63479, 30326, 36494}
+        set ANSI green color to {16705, 42662, 46517}
+        set ANSI yellow color to {57568, 44975, 26728}
+        set ANSI blue color to {31354, 41634, 63479}
+        set ANSI magenta color to {48059, 39578, 63479}
+        set ANSI cyan color to {32125, 53199, 65535}
+        set ANSI white color to {52171, 52428, 53713}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12079, 13621, 18761}
+        set ANSI bright red color to {63479, 30326, 36494}
+        set ANSI bright green color to {16705, 42662, 46517}
+        set ANSI bright yellow color to {57568, 44975, 26728}
+        set ANSI bright blue color to {31354, 41634, 63479}
+        set ANSI bright magenta color to {48059, 39578, 63479}
+        set ANSI bright cyan color to {32125, 53199, 65535}
+        set ANSI bright white color to {54741, 54998, 56283}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-terminal-light.sh
+++ b/scripts/base16-tokyo-night-terminal-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {54741, 54998, 56283}
+        set foreground color to {19532, 20560, 24158}
+
+        -- Set ANSI Colors
+        set ANSI black color to {54741, 54998, 56283}
+        set ANSI red color to {35980, 17219, 20817}
+        set ANSI green color to {13107, 25443, 23644}
+        set ANSI yellow color to {36751, 24158, 5397}
+        set ANSI blue color to {13364, 21588, 35466}
+        set ANSI magenta color to {23130, 19018, 30840}
+        set ANSI cyan color to {3855, 19275, 28270}
+        set ANSI white color to {6682, 6939, 9766}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {57311, 57568, 58853}
+        set ANSI bright red color to {35980, 17219, 20817}
+        set ANSI bright green color to {13107, 25443, 23644}
+        set ANSI bright yellow color to {36751, 24158, 5397}
+        set ANSI bright blue color to {13364, 21588, 35466}
+        set ANSI bright magenta color to {23130, 19018, 30840}
+        set ANSI bright cyan color to {3855, 19275, 28270}
+        set ANSI bright white color to {6682, 6939, 9766}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyo-night-terminal-storm.sh
+++ b/scripts/base16-tokyo-night-terminal-storm.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9252, 10280, 15163}
+        set foreground color to {30840, 31868, 39321}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9252, 10280, 15163}
+        set ANSI red color to {63479, 30326, 36494}
+        set ANSI green color to {16705, 42662, 46517}
+        set ANSI yellow color to {57568, 44975, 26728}
+        set ANSI blue color to {31354, 41634, 63479}
+        set ANSI magenta color to {48059, 39578, 63479}
+        set ANSI cyan color to {32125, 53199, 65535}
+        set ANSI white color to {52171, 52428, 53713}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {13364, 14906, 21074}
+        set ANSI bright red color to {63479, 30326, 36494}
+        set ANSI bright green color to {16705, 42662, 46517}
+        set ANSI bright yellow color to {57568, 44975, 26728}
+        set ANSI bright blue color to {31354, 41634, 63479}
+        set ANSI bright magenta color to {48059, 39578, 63479}
+        set ANSI bright cyan color to {32125, 53199, 65535}
+        set ANSI bright white color to {54741, 54998, 56283}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyodark-terminal.sh
+++ b/scripts/base16-tokyodark-terminal.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4626, 7453}
+        set foreground color to {41120, 43176, 52685}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4626, 7453}
+        set ANSI red color to {61166, 28013, 34181}
+        set ANSI green color to {38293, 50629, 24929}
+        set ANSI yellow color to {55255, 42662, 24415}
+        set ANSI blue color to {29041, 39321, 61166}
+        set ANSI magenta color to {42148, 34181, 56797}
+        set ANSI cyan color to {14392, 43176, 40349}
+        set ANSI white color to {41120, 43176, 52685}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8481, 8738, 13364}
+        set ANSI bright red color to {61166, 28013, 34181}
+        set ANSI bright green color to {38293, 50629, 24929}
+        set ANSI bright yellow color to {55255, 42662, 24415}
+        set ANSI bright blue color to {29041, 39321, 61166}
+        set ANSI bright magenta color to {42148, 34181, 56797}
+        set ANSI bright cyan color to {14392, 43176, 40349}
+        set ANSI bright white color to {41120, 43176, 52685}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tokyodark.sh
+++ b/scripts/base16-tokyodark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4626, 7453}
+        set foreground color to {41120, 43176, 52685}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4626, 7453}
+        set ANSI red color to {61166, 28013, 34181}
+        set ANSI green color to {38293, 50629, 24929}
+        set ANSI yellow color to {55255, 42662, 24415}
+        set ANSI blue color to {29041, 39321, 61166}
+        set ANSI magenta color to {42148, 34181, 56797}
+        set ANSI cyan color to {40863, 48059, 62451}
+        set ANSI white color to {43947, 45746, 49087}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8481, 8738, 13364}
+        set ANSI bright red color to {61166, 28013, 34181}
+        set ANSI bright green color to {38293, 50629, 24929}
+        set ANSI bright yellow color to {55255, 42662, 24415}
+        set ANSI bright blue color to {29041, 39321, 61166}
+        set ANSI bright magenta color to {42148, 34181, 56797}
+        set ANSI bright cyan color to {40863, 48059, 62451}
+        set ANSI bright white color to {48316, 49858, 56540}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tomorrow-night-eighties.sh
+++ b/scripts/base16-tomorrow-night-eighties.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11565, 11565, 11565}
+        set foreground color to {52428, 52428, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11565, 11565, 11565}
+        set ANSI red color to {62194, 30583, 31354}
+        set ANSI green color to {39321, 52428, 39321}
+        set ANSI yellow color to {65535, 52428, 26214}
+        set ANSI blue color to {26214, 39321, 52428}
+        set ANSI magenta color to {52428, 39321, 52428}
+        set ANSI cyan color to {26214, 52428, 52428}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20817, 20817, 20817}
+        set ANSI bright red color to {62194, 30583, 31354}
+        set ANSI bright green color to {39321, 52428, 39321}
+        set ANSI bright yellow color to {65535, 52428, 26214}
+        set ANSI bright blue color to {26214, 39321, 52428}
+        set ANSI bright magenta color to {52428, 39321, 52428}
+        set ANSI bright cyan color to {26214, 52428, 52428}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tomorrow-night.sh
+++ b/scripts/base16-tomorrow-night.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7453, 7967, 8481}
+        set foreground color to {50629, 51400, 50886}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7453, 7967, 8481}
+        set ANSI red color to {52428, 26214, 26214}
+        set ANSI green color to {46517, 48573, 26728}
+        set ANSI yellow color to {61680, 50886, 29812}
+        set ANSI blue color to {33153, 41634, 48830}
+        set ANSI magenta color to {45746, 38036, 48059}
+        set ANSI cyan color to {35466, 48830, 47031}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14135, 15163, 16705}
+        set ANSI bright red color to {52428, 26214, 26214}
+        set ANSI bright green color to {46517, 48573, 26728}
+        set ANSI bright yellow color to {61680, 50886, 29812}
+        set ANSI bright blue color to {33153, 41634, 48830}
+        set ANSI bright magenta color to {45746, 38036, 48059}
+        set ANSI bright cyan color to {35466, 48830, 47031}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tomorrow.sh
+++ b/scripts/base16-tomorrow.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {19789, 19789, 19532}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {51400, 10280, 10537}
+        set ANSI green color to {29041, 35980, 0}
+        set ANSI yellow color to {60138, 47031, 0}
+        set ANSI blue color to {16962, 29041, 44718}
+        set ANSI magenta color to {35209, 22873, 43176}
+        set ANSI cyan color to {15934, 39321, 40863}
+        set ANSI white color to {10280, 10794, 11822}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54998, 54998, 54998}
+        set ANSI bright red color to {51400, 10280, 10537}
+        set ANSI bright green color to {29041, 35980, 0}
+        set ANSI bright yellow color to {60138, 47031, 0}
+        set ANSI bright blue color to {16962, 29041, 44718}
+        set ANSI bright magenta color to {35209, 22873, 43176}
+        set ANSI bright cyan color to {15934, 39321, 40863}
+        set ANSI bright white color to {7453, 7967, 8481}
+    end tell
+end tell
+EOF

--- a/scripts/base16-tube.sh
+++ b/scripts/base16-tube.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 7967, 8224}
+        set foreground color to {55769, 55512, 55512}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 7967, 8224}
+        set ANSI red color to {61166, 11822, 9252}
+        set ANSI green color to {0, 34181, 15934}
+        set ANSI yellow color to {65535, 53970, 1028}
+        set ANSI blue color to {0, 40349, 56540}
+        set ANSI magenta color to {39064, 0, 23901}
+        set ANSI cyan color to {34181, 52942, 48316}
+        set ANSI white color to {59367, 59367, 59624}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {23130, 22359, 22616}
+        set ANSI bright red color to {61166, 11822, 9252}
+        set ANSI bright green color to {0, 34181, 15934}
+        set ANSI bright yellow color to {65535, 53970, 1028}
+        set ANSI bright blue color to {0, 40349, 56540}
+        set ANSI bright magenta color to {39064, 0, 23901}
+        set ANSI bright cyan color to {34181, 52942, 48316}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-twilight.sh
+++ b/scripts/base16-twilight.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {7710, 7710, 7710}
+        set foreground color to {42919, 42919, 42919}
+
+        -- Set ANSI Colors
+        set ANSI black color to {7710, 7710, 7710}
+        set ANSI red color to {53199, 27242, 19532}
+        set ANSI green color to {36751, 40349, 27242}
+        set ANSI yellow color to {63993, 61166, 39064}
+        set ANSI blue color to {30069, 34695, 42662}
+        set ANSI magenta color to {39835, 34181, 40349}
+        set ANSI cyan color to {44975, 50372, 56283}
+        set ANSI white color to {50115, 50115, 50115}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17990, 19275, 20560}
+        set ANSI bright red color to {53199, 27242, 19532}
+        set ANSI bright green color to {36751, 40349, 27242}
+        set ANSI bright yellow color to {63993, 61166, 39064}
+        set ANSI bright blue color to {30069, 34695, 42662}
+        set ANSI bright magenta color to {39835, 34181, 40349}
+        set ANSI bright cyan color to {44975, 50372, 56283}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-unikitty-dark.sh
+++ b/scripts/base16-unikitty-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11822, 10794, 12593}
+        set foreground color to {48316, 47802, 48830}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11822, 10794, 12593}
+        set ANSI red color to {55512, 4883, 32639}
+        set ANSI green color to {5911, 44461, 39064}
+        set ANSI yellow color to {56540, 35466, 3598}
+        set ANSI blue color to {31097, 27242, 62965}
+        set ANSI magenta color to {48059, 24672, 60138}
+        set ANSI cyan color to {5140, 39835, 56026}
+        set ANSI white color to {55512, 55255, 56026}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {26214, 25443, 26985}
+        set ANSI bright red color to {55512, 4883, 32639}
+        set ANSI bright green color to {5911, 44461, 39064}
+        set ANSI bright yellow color to {56540, 35466, 3598}
+        set ANSI bright blue color to {31097, 27242, 62965}
+        set ANSI bright magenta color to {48059, 24672, 60138}
+        set ANSI bright cyan color to {5140, 39835, 56026}
+        set ANSI bright white color to {62965, 62708, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-unikitty-light.sh
+++ b/scripts/base16-unikitty-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {27756, 26985, 28270}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {55512, 4883, 32639}
+        set ANSI green color to {5911, 44461, 39064}
+        set ANSI yellow color to {56540, 35466, 3598}
+        set ANSI blue color to {30583, 23901, 65535}
+        set ANSI magenta color to {43690, 5911, 59110}
+        set ANSI cyan color to {5140, 39835, 56026}
+        set ANSI white color to {20303, 19275, 20817}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {50372, 50115, 50629}
+        set ANSI bright red color to {55512, 4883, 32639}
+        set ANSI bright green color to {5911, 44461, 39064}
+        set ANSI bright yellow color to {56540, 35466, 3598}
+        set ANSI bright blue color to {30583, 23901, 65535}
+        set ANSI bright magenta color to {43690, 5911, 59110}
+        set ANSI bright cyan color to {5140, 39835, 56026}
+        set ANSI bright white color to {12850, 11565, 13364}
+    end tell
+end tell
+EOF

--- a/scripts/base16-unikitty-reversible.sh
+++ b/scripts/base16-unikitty-reversible.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {11822, 10794, 12593}
+        set foreground color to {50115, 49858, 50372}
+
+        -- Set ANSI Colors
+        set ANSI black color to {11822, 10794, 12593}
+        set ANSI red color to {55512, 4883, 32639}
+        set ANSI green color to {5911, 44461, 39064}
+        set ANSI yellow color to {56540, 35466, 3598}
+        set ANSI blue color to {30840, 25700, 64250}
+        set ANSI magenta color to {46003, 15420, 59624}
+        set ANSI cyan color to {5140, 39835, 56026}
+        set ANSI white color to {57825, 57568, 57825}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {26985, 26214, 27499}
+        set ANSI bright red color to {55512, 4883, 32639}
+        set ANSI bright green color to {5911, 44461, 39064}
+        set ANSI bright yellow color to {56540, 35466, 3598}
+        set ANSI bright blue color to {30840, 25700, 64250}
+        set ANSI bright magenta color to {46003, 15420, 59624}
+        set ANSI bright cyan color to {5140, 39835, 56026}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-uwunicorn.sh
+++ b/scripts/base16-uwunicorn.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9252, 6939, 9766}
+        set foreground color to {61166, 54741, 55769}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9252, 6939, 9766}
+        set ANSI red color to {34695, 31611, 46774}
+        set ANSI green color to {51657, 25957, 49087}
+        set ANSI yellow color to {43176, 19018, 29555}
+        set ANSI blue color to {27242, 40606, 46517}
+        set ANSI magenta color to {30840, 41891, 36751}
+        set ANSI cyan color to {40092, 24415, 52942}
+        set ANSI white color to {55769, 49858, 50886}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17990, 13621, 19018}
+        set ANSI bright red color to {34695, 31611, 46774}
+        set ANSI bright green color to {51657, 25957, 49087}
+        set ANSI bright yellow color to {43176, 19018, 29555}
+        set ANSI bright blue color to {27242, 40606, 46517}
+        set ANSI bright magenta color to {30840, 41891, 36751}
+        set ANSI bright cyan color to {40092, 24415, 52942}
+        set ANSI bright white color to {58596, 52428, 53456}
+    end tell
+end tell
+EOF

--- a/scripts/base16-vesper.sh
+++ b/scripts/base16-vesper.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4112, 4112, 4112}
+        set foreground color to {47031, 47031, 47031}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4112, 4112, 4112}
+        set ANSI red color to {57054, 28270, 28270}
+        set ANSI green color to {24415, 34695, 34695}
+        set ANSI yellow color to {65535, 51143, 39321}
+        set ANSI blue color to {36494, 43690, 43690}
+        set ANSI magenta color to {54998, 37008, 38036}
+        set ANSI cyan color to {24672, 42405, 37522}
+        set ANSI white color to {49601, 49601, 49601}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {8738, 8738, 8738}
+        set ANSI bright red color to {57054, 28270, 28270}
+        set ANSI bright green color to {24415, 34695, 34695}
+        set ANSI bright yellow color to {65535, 51143, 39321}
+        set ANSI bright blue color to {36494, 43690, 43690}
+        set ANSI bright magenta color to {54998, 37008, 38036}
+        set ANSI bright cyan color to {24672, 42405, 37522}
+        set ANSI bright white color to {54741, 54741, 54741}
+    end tell
+end tell
+EOF

--- a/scripts/base16-vice.sh
+++ b/scripts/base16-vice.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5911, 6425, 7710}
+        set foreground color to {35723, 40092, 48830}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5911, 6425, 7710}
+        set ANSI red color to {65535, 10537, 43176}
+        set ANSI green color to {2827, 44461, 65535}
+        set ANSI yellow color to {61680, 65535, 43690}
+        set ANSI blue color to {0, 60138, 65535}
+        set ANSI magenta color to {0, 63222, 55769}
+        set ANSI cyan color to {33410, 25957, 65535}
+        set ANSI white color to {45746, 49087, 55769}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {15420, 16191, 19532}
+        set ANSI bright red color to {65535, 10537, 43176}
+        set ANSI bright green color to {2827, 44461, 65535}
+        set ANSI bright yellow color to {61680, 65535, 43690}
+        set ANSI bright blue color to {0, 60138, 65535}
+        set ANSI bright magenta color to {0, 63222, 55769}
+        set ANSI bright cyan color to {33410, 25957, 65535}
+        set ANSI bright white color to {62708, 62708, 63479}
+    end tell
+end tell
+EOF

--- a/scripts/base16-vulcan.sh
+++ b/scripts/base16-vulcan.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1028, 5397, 8995}
+        set foreground color to {23387, 30583, 35980}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1028, 5397, 8995}
+        set ANSI red color to {33153, 34181, 37265}
+        set ANSI green color to {38807, 32125, 31868}
+        set ANSI yellow color to {44461, 46260, 47545}
+        set ANSI blue color to {38807, 32125, 31868}
+        set ANSI magenta color to {37265, 39064, 41891}
+        set ANSI cyan color to {38807, 32125, 31868}
+        set ANSI white color to {13107, 12850, 14392}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 13621, 21074}
+        set ANSI bright red color to {33153, 34181, 37265}
+        set ANSI bright green color to {38807, 32125, 31868}
+        set ANSI bright yellow color to {44461, 46260, 47545}
+        set ANSI bright blue color to {38807, 32125, 31868}
+        set ANSI bright magenta color to {37265, 39064, 41891}
+        set ANSI bright cyan color to {38807, 32125, 31868}
+        set ANSI bright white color to {8481, 19789, 26728}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-10-light.sh
+++ b/scripts/base16-windows-10-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62194, 62194, 62194}
+        set foreground color to {30326, 30326, 30326}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62194, 62194, 62194}
+        set ANSI red color to {50629, 3855, 7967}
+        set ANSI green color to {4883, 41377, 3598}
+        set ANSI yellow color to {49601, 40092, 0}
+        set ANSI blue color to {0, 14135, 56026}
+        set ANSI magenta color to {34952, 5911, 39064}
+        set ANSI cyan color to {14906, 38550, 56797}
+        set ANSI white color to {16705, 16705, 16705}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {55769, 55769, 55769}
+        set ANSI bright red color to {50629, 3855, 7967}
+        set ANSI bright green color to {4883, 41377, 3598}
+        set ANSI bright yellow color to {49601, 40092, 0}
+        set ANSI bright blue color to {0, 14135, 56026}
+        set ANSI bright magenta color to {34952, 5911, 39064}
+        set ANSI bright cyan color to {14906, 38550, 56797}
+        set ANSI bright white color to {3084, 3084, 3084}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-10.sh
+++ b/scripts/base16-windows-10.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {3084, 3084, 3084}
+        set foreground color to {52428, 52428, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {3084, 3084, 3084}
+        set ANSI red color to {59367, 18504, 22102}
+        set ANSI green color to {5654, 50886, 3084}
+        set ANSI yellow color to {63993, 61937, 42405}
+        set ANSI blue color to {15163, 30840, 65535}
+        set ANSI magenta color to {46260, 0, 40606}
+        set ANSI cyan color to {24929, 54998, 54998}
+        set ANSI white color to {57311, 57311, 57311}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21331, 21331, 21331}
+        set ANSI bright red color to {59367, 18504, 22102}
+        set ANSI bright green color to {5654, 50886, 3084}
+        set ANSI bright yellow color to {63993, 61937, 42405}
+        set ANSI bright blue color to {15163, 30840, 65535}
+        set ANSI bright magenta color to {46260, 0, 40606}
+        set ANSI bright cyan color to {24929, 54998, 54998}
+        set ANSI bright white color to {62194, 62194, 62194}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-95-light.sh
+++ b/scripts/base16-windows-95-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64764, 64764, 64764}
+        set foreground color to {21588, 21588, 21588}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64764, 64764, 64764}
+        set ANSI red color to {43176, 0, 0}
+        set ANSI green color to {0, 43176, 0}
+        set ANSI yellow color to {43176, 21588, 0}
+        set ANSI blue color to {0, 0, 43176}
+        set ANSI magenta color to {43176, 0, 43176}
+        set ANSI cyan color to {0, 43176, 43176}
+        set ANSI white color to {10794, 10794, 10794}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {50372, 50372, 50372}
+        set ANSI bright red color to {43176, 0, 0}
+        set ANSI bright green color to {0, 43176, 0}
+        set ANSI bright yellow color to {43176, 21588, 0}
+        set ANSI bright blue color to {0, 0, 43176}
+        set ANSI bright magenta color to {43176, 0, 43176}
+        set ANSI bright cyan color to {0, 43176, 43176}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-95.sh
+++ b/scripts/base16-windows-95.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {43176, 43176, 43176}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {64764, 21588, 21588}
+        set ANSI green color to {21588, 64764, 21588}
+        set ANSI yellow color to {64764, 64764, 21588}
+        set ANSI blue color to {21588, 21588, 64764}
+        set ANSI magenta color to {64764, 21588, 64764}
+        set ANSI cyan color to {21588, 64764, 64764}
+        set ANSI white color to {53970, 53970, 53970}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14392, 14392, 14392}
+        set ANSI bright red color to {64764, 21588, 21588}
+        set ANSI bright green color to {21588, 64764, 21588}
+        set ANSI bright yellow color to {64764, 64764, 21588}
+        set ANSI bright blue color to {21588, 21588, 64764}
+        set ANSI bright magenta color to {64764, 21588, 64764}
+        set ANSI bright cyan color to {21588, 64764, 64764}
+        set ANSI bright white color to {64764, 64764, 64764}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-highcontrast-light.sh
+++ b/scripts/base16-windows-highcontrast-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {64764, 64764, 64764}
+        set foreground color to {21588, 21588, 21588}
+
+        -- Set ANSI Colors
+        set ANSI black color to {64764, 64764, 64764}
+        set ANSI red color to {32896, 0, 0}
+        set ANSI green color to {0, 32896, 0}
+        set ANSI yellow color to {32896, 32896, 0}
+        set ANSI blue color to {0, 0, 32896}
+        set ANSI magenta color to {32896, 0, 32896}
+        set ANSI cyan color to {0, 32896, 32896}
+        set ANSI white color to {10794, 10794, 10794}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54484, 54484, 54484}
+        set ANSI bright red color to {32896, 0, 0}
+        set ANSI bright green color to {0, 32896, 0}
+        set ANSI bright yellow color to {32896, 32896, 0}
+        set ANSI bright blue color to {0, 0, 32896}
+        set ANSI bright magenta color to {32896, 0, 32896}
+        set ANSI bright cyan color to {0, 32896, 32896}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-highcontrast.sh
+++ b/scripts/base16-windows-highcontrast.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49344, 49344, 49344}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {64764, 21588, 21588}
+        set ANSI green color to {21588, 64764, 21588}
+        set ANSI yellow color to {64764, 64764, 21588}
+        set ANSI blue color to {21588, 21588, 64764}
+        set ANSI magenta color to {64764, 21588, 64764}
+        set ANSI cyan color to {21588, 64764, 64764}
+        set ANSI white color to {57054, 57054, 57054}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {14392, 14392, 14392}
+        set ANSI bright red color to {64764, 21588, 21588}
+        set ANSI bright green color to {21588, 64764, 21588}
+        set ANSI bright yellow color to {64764, 64764, 21588}
+        set ANSI bright blue color to {21588, 21588, 64764}
+        set ANSI bright magenta color to {64764, 21588, 64764}
+        set ANSI bright cyan color to {21588, 64764, 64764}
+        set ANSI bright white color to {64764, 64764, 64764}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-nt-light.sh
+++ b/scripts/base16-windows-nt-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {65535, 65535, 65535}
+        set foreground color to {32896, 32896, 32896}
+
+        -- Set ANSI Colors
+        set ANSI black color to {65535, 65535, 65535}
+        set ANSI red color to {32896, 0, 0}
+        set ANSI green color to {0, 32896, 0}
+        set ANSI yellow color to {32896, 32896, 0}
+        set ANSI blue color to {0, 0, 32896}
+        set ANSI magenta color to {32896, 0, 32896}
+        set ANSI cyan color to {0, 32896, 32896}
+        set ANSI white color to {16448, 16448, 16448}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {54741, 54741, 54741}
+        set ANSI bright red color to {32896, 0, 0}
+        set ANSI bright green color to {0, 32896, 0}
+        set ANSI bright yellow color to {32896, 32896, 0}
+        set ANSI bright blue color to {0, 0, 32896}
+        set ANSI bright magenta color to {32896, 0, 32896}
+        set ANSI bright cyan color to {0, 32896, 32896}
+        set ANSI bright white color to {0, 0, 0}
+    end tell
+end tell
+EOF

--- a/scripts/base16-windows-nt.sh
+++ b/scripts/base16-windows-nt.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {49344, 49344, 49344}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {65535, 0, 0}
+        set ANSI green color to {0, 65535, 0}
+        set ANSI yellow color to {65535, 65535, 0}
+        set ANSI blue color to {0, 0, 65535}
+        set ANSI magenta color to {65535, 0, 65535}
+        set ANSI cyan color to {0, 65535, 65535}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21845, 21845, 21845}
+        set ANSI bright red color to {65535, 0, 0}
+        set ANSI bright green color to {0, 65535, 0}
+        set ANSI bright yellow color to {65535, 65535, 0}
+        set ANSI bright blue color to {0, 0, 65535}
+        set ANSI bright magenta color to {65535, 0, 65535}
+        set ANSI bright cyan color to {0, 65535, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base16-woodland.sh
+++ b/scripts/base16-woodland.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {8995, 7710, 6168}
+        set foreground color to {51914, 48316, 45489}
+
+        -- Set ANSI Colors
+        set ANSI black color to {8995, 7710, 6168}
+        set ANSI red color to {54227, 23644, 23644}
+        set ANSI green color to {47031, 47802, 21331}
+        set ANSI yellow color to {57568, 44204, 5654}
+        set ANSI blue color to {34952, 42148, 54227}
+        set ANSI magenta color to {48059, 37008, 58082}
+        set ANSI cyan color to {28270, 47545, 22616}
+        set ANSI white color to {55255, 51400, 48316}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {18504, 16705, 14906}
+        set ANSI bright red color to {54227, 23644, 23644}
+        set ANSI bright green color to {47031, 47802, 21331}
+        set ANSI bright yellow color to {57568, 44204, 5654}
+        set ANSI bright blue color to {34952, 42148, 54227}
+        set ANSI bright magenta color to {48059, 37008, 58082}
+        set ANSI bright cyan color to {28270, 47545, 22616}
+        set ANSI bright white color to {58596, 54484, 51400}
+    end tell
+end tell
+EOF

--- a/scripts/base16-xcode-dusk.sh
+++ b/scripts/base16-xcode-dusk.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 11051, 13621}
+        set foreground color to {37779, 38293, 39321}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 11051, 13621}
+        set ANSI red color to {45746, 6168, 35209}
+        set ANSI green color to {57311, 0, 514}
+        set ANSI yellow color to {17219, 33410, 34952}
+        set ANSI blue color to {31097, 3598, 44461}
+        set ANSI magenta color to {45746, 6168, 35209}
+        set ANSI cyan color to {0, 41120, 48830}
+        set ANSI white color to {43433, 43690, 44718}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21331, 21845, 23901}
+        set ANSI bright red color to {45746, 6168, 35209}
+        set ANSI bright green color to {57311, 0, 514}
+        set ANSI bright yellow color to {17219, 33410, 34952}
+        set ANSI bright blue color to {31097, 3598, 44461}
+        set ANSI bright magenta color to {45746, 6168, 35209}
+        set ANSI bright cyan color to {0, 41120, 48830}
+        set ANSI bright white color to {48830, 49087, 49858}
+    end tell
+end tell
+EOF

--- a/scripts/base16-zenbones.sh
+++ b/scripts/base16-zenbones.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {6425, 6425, 6425}
+        set foreground color to {45746, 31097, 42919}
+
+        -- Set ANSI Colors
+        set ANSI black color to {6425, 6425, 6425}
+        set ANSI red color to {15677, 14392, 14649}
+        set ANSI green color to {54998, 35980, 26471}
+        set ANSI yellow color to {35723, 44718, 26728}
+        set ANSI blue color to {53199, 34438, 49601}
+        set ANSI magenta color to {25957, 47288, 49601}
+        set ANSI cyan color to {24929, 43947, 56026}
+        set ANSI white color to {26214, 42405, 44461}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {33153, 39835, 26985}
+        set ANSI bright red color to {15677, 14392, 14649}
+        set ANSI bright green color to {54998, 35980, 26471}
+        set ANSI bright yellow color to {35723, 44718, 26728}
+        set ANSI bright blue color to {53199, 34438, 49601}
+        set ANSI bright magenta color to {25957, 47288, 49601}
+        set ANSI bright cyan color to {24929, 43947, 56026}
+        set ANSI bright white color to {48059, 48059, 48059}
+    end tell
+end tell
+EOF

--- a/scripts/base16-zenburn.sh
+++ b/scripts/base16-zenburn.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {14392, 14392, 14392}
+        set foreground color to {56540, 56540, 52428}
+
+        -- Set ANSI Colors
+        set ANSI black color to {14392, 14392, 14392}
+        set ANSI red color to {56540, 41891, 41891}
+        set ANSI green color to {24415, 32639, 24415}
+        set ANSI yellow color to {57568, 53199, 40863}
+        set ANSI blue color to {31868, 47288, 48059}
+        set ANSI magenta color to {56540, 35980, 50115}
+        set ANSI cyan color to {37779, 57568, 58339}
+        set ANSI white color to {49344, 49344, 49344}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {24672, 24672, 24672}
+        set ANSI bright red color to {56540, 41891, 41891}
+        set ANSI bright green color to {24415, 32639, 24415}
+        set ANSI bright yellow color to {57568, 53199, 40863}
+        set ANSI bright blue color to {31868, 47288, 48059}
+        set ANSI bright magenta color to {56540, 35980, 50115}
+        set ANSI bright cyan color to {37779, 57568, 58339}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-brogrammer.sh
+++ b/scripts/base24-brogrammer.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4883, 4883, 4883}
+        set foreground color to {49601, 51400, 55255}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4883, 4883, 4883}
+        set ANSI red color to {63479, 4369, 6168}
+        set ANSI green color to {11308, 50629, 23901}
+        set ANSI yellow color to {3855, 32896, 54741}
+        set ANSI blue color to {10794, 33924, 53970}
+        set ANSI magenta color to {20046, 22873, 47031}
+        set ANSI cyan color to {3855, 32896, 54741}
+        set ANSI white color to {58339, 59110, 60909}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {10794, 12593, 16705}
+        set ANSI bright red color to {57054, 13364, 11822}
+        set ANSI bright green color to {7453, 53970, 24672}
+        set ANSI bright yellow color to {62194, 48573, 2313}
+        set ANSI bright blue color to {20560, 39835, 56540}
+        set ANSI bright magenta color to {21074, 20303, 47545}
+        set ANSI bright cyan color to {10280, 39578, 61680}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-chalk.sh
+++ b/scripts/base24-chalk.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {5397, 5397, 5397}
+        set foreground color to {53456, 53456, 53456}
+
+        -- Set ANSI Colors
+        set ANSI black color to {5397, 5397, 5397}
+        set ANSI red color to {64250, 34181, 40092}
+        set ANSI green color to {41377, 48059, 21588}
+        set ANSI yellow color to {56797, 45746, 28527}
+        set ANSI blue color to {23130, 47545, 60909}
+        set ANSI magenta color to {56283, 36751, 60138}
+        set ANSI cyan color to {4112, 48316, 44461}
+        set ANSI white color to {57568, 57568, 57568}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {12336, 12336, 12336}
+        set ANSI bright red color to {64507, 40863, 45489}
+        set ANSI bright green color to {44204, 49858, 26471}
+        set ANSI bright yellow color to {60909, 43433, 34695}
+        set ANSI bright blue color to {28527, 49858, 61423}
+        set ANSI bright magenta color to {57825, 41891, 61166}
+        set ANSI bright cyan color to {4626, 53199, 49344}
+        set ANSI bright white color to {62965, 62965, 62965}
+    end tell
+end tell
+EOF

--- a/scripts/base24-dracula.sh
+++ b/scripts/base24-dracula.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 10794, 13878}
+        set foreground color to {63736, 63736, 62194}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 10794, 13878}
+        set ANSI red color to {65535, 21845, 21845}
+        set ANSI green color to {20560, 64250, 31611}
+        set ANSI yellow color to {61937, 64250, 35980}
+        set ANSI blue color to {32896, 49087, 65535}
+        set ANSI magenta color to {65535, 31097, 50886}
+        set ANSI cyan color to {35723, 59881, 65021}
+        set ANSI white color to {61680, 61937, 62708}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {17476, 18247, 23130}
+        set ANSI bright red color to {62194, 35980, 35980}
+        set ANSI bright green color to {41891, 62965, 47288}
+        set ANSI bright yellow color to {61166, 62965, 41891}
+        set ANSI bright blue color to {41891, 52428, 62965}
+        set ANSI bright magenta color to {62965, 41891, 53970}
+        set ANSI bright cyan color to {47802, 60909, 63479}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-espresso.sh
+++ b/scripts/base24-espresso.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {9766, 9766, 9766}
+        set foreground color to {51143, 51143, 50629}
+
+        -- Set ANSI Colors
+        set ANSI black color to {9766, 9766, 9766}
+        set ANSI red color to {53970, 20817, 20817}
+        set ANSI green color to {42405, 49858, 24929}
+        set ANSI yellow color to {35466, 47031, 55769}
+        set ANSI blue color to {27756, 39321, 48059}
+        set ANSI magenta color to {53713, 38807, 55769}
+        set ANSI cyan color to {48830, 54998, 65535}
+        set ANSI white color to {61166, 61166, 60652}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {21331, 21331, 21331}
+        set ANSI bright red color to {61680, 3084, 3084}
+        set ANSI bright green color to {49858, 57568, 30069}
+        set ANSI bright yellow color to {57825, 58339, 35723}
+        set ANSI bright blue color to {35466, 47031, 55769}
+        set ANSI bright magenta color to {61423, 46517, 63479}
+        set ANSI bright cyan color to {56540, 62451, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-flat.sh
+++ b/scripts/base24-flat.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {2056, 10280, 17733}
+        set foreground color to {35980, 37779, 39578}
+
+        -- Set ANSI Colors
+        set ANSI black color to {2056, 10280, 17733}
+        set ANSI red color to {43176, 8995, 8224}
+        set ANSI green color to {11565, 38036, 16448}
+        set ANSI yellow color to {15420, 32125, 53970}
+        set ANSI blue color to {12593, 26471, 44204}
+        set ANSI magenta color to {30840, 6682, 41120}
+        set ANSI cyan color to {11308, 37779, 28784}
+        set ANSI white color to {45232, 46774, 47802}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {11822, 11822, 17733}
+        set ANSI bright red color to {54484, 12593, 11822}
+        set ANSI bright green color to {12850, 42405, 18504}
+        set ANSI bright yellow color to {58853, 48830, 3084}
+        set ANSI bright blue color to {15420, 32125, 53970}
+        set ANSI bright magenta color to {33410, 12336, 42919}
+        set ANSI bright cyan color to {13621, 46003, 34695}
+        set ANSI bright white color to {59367, 60652, 60909}
+    end tell
+end tell
+EOF

--- a/scripts/base24-framer.sh
+++ b/scripts/base24-framer.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4369, 4369}
+        set foreground color to {43433, 43433, 43433}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4369, 4369}
+        set ANSI red color to {65535, 21845, 21845}
+        set ANSI green color to {39064, 60652, 25957}
+        set ANSI yellow color to {13107, 48059, 65535}
+        set ANSI blue color to {0, 43690, 65535}
+        set ANSI magenta color to {43690, 34952, 65535}
+        set ANSI cyan color to {34952, 56797, 65535}
+        set ANSI white color to {52428, 52428, 52428}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16705, 16705, 16705}
+        set ANSI bright red color to {65535, 34952, 34952}
+        set ANSI bright green color to {46774, 62194, 37522}
+        set ANSI bright yellow color to {65535, 55769, 26214}
+        set ANSI bright blue color to {13107, 48059, 65535}
+        set ANSI bright magenta color to {52942, 48059, 65535}
+        set ANSI bright cyan color to {48059, 60652, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-github.sh
+++ b/scripts/base24-github.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {62708, 62708, 62708}
+        set foreground color to {55512, 55512, 55512}
+
+        -- Set ANSI Colors
+        set ANSI black color to {62708, 62708, 62708}
+        set ANSI red color to {38807, 2827, 5654}
+        set ANSI green color to {1799, 38550, 10794}
+        set ANSI yellow color to {11822, 27756, 47802}
+        set ANSI blue color to {0, 15934, 35466}
+        set ANSI magenta color to {59881, 17990, 37265}
+        set ANSI cyan color to {35209, 53713, 60652}
+        set ANSI white color to {65535, 65535, 65535}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {26214, 26214, 26214}
+        set ANSI bright red color to {57054, 0, 0}
+        set ANSI bright green color to {34695, 54741, 41634}
+        set ANSI bright yellow color to {61937, 53456, 1799}
+        set ANSI bright blue color to {11822, 27756, 47802}
+        set ANSI bright magenta color to {65535, 41634, 40863}
+        set ANSI bright cyan color to {7196, 64250, 65278}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-hardcore.sh
+++ b/scripts/base24-hardcore.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {4369, 4369, 4369}
+        set foreground color to {43433, 43433, 43433}
+
+        -- Set ANSI Colors
+        set ANSI black color to {4369, 4369, 4369}
+        set ANSI red color to {65535, 21845, 21845}
+        set ANSI green color to {39064, 60652, 25957}
+        set ANSI yellow color to {13107, 48059, 65535}
+        set ANSI blue color to {0, 43690, 65535}
+        set ANSI magenta color to {43690, 34952, 65535}
+        set ANSI cyan color to {34952, 56797, 65535}
+        set ANSI white color to {52428, 52428, 52428}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {16705, 16705, 16705}
+        set ANSI bright red color to {65535, 34952, 34952}
+        set ANSI bright green color to {46774, 62194, 37522}
+        set ANSI bright yellow color to {65535, 55769, 26214}
+        set ANSI bright blue color to {13107, 48059, 65535}
+        set ANSI bright magenta color to {52942, 48059, 65535}
+        set ANSI bright cyan color to {48059, 60652, 65535}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-one-black.sh
+++ b/scripts/base24-one-black.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {0, 0, 0}
+        set foreground color to {43947, 45746, 49087}
+
+        -- Set ANSI Colors
+        set ANSI black color to {0, 0, 0}
+        set ANSI red color to {57568, 21845, 24929}
+        set ANSI green color to {35980, 49858, 25957}
+        set ANSI yellow color to {59110, 47545, 25957}
+        set ANSI blue color to {19018, 42405, 61680}
+        set ANSI magenta color to {49601, 25186, 57054}
+        set ANSI cyan color to {16962, 46003, 49858}
+        set ANSI white color to {59110, 59110, 59110}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20303, 22102, 26214}
+        set ANSI bright red color to {65535, 24929, 28270}
+        set ANSI bright green color to {42405, 57568, 30069}
+        set ANSI bright yellow color to {61680, 42148, 23901}
+        set ANSI bright blue color to {19789, 50372, 65535}
+        set ANSI bright magenta color to {57054, 29555, 65535}
+        set ANSI bright cyan color to {19532, 53713, 57568}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-one-dark.sh
+++ b/scripts/base24-one-dark.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {10280, 11308, 13364}
+        set foreground color to {43947, 45746, 49087}
+
+        -- Set ANSI Colors
+        set ANSI black color to {10280, 11308, 13364}
+        set ANSI red color to {57568, 21845, 24929}
+        set ANSI green color to {35980, 49858, 25957}
+        set ANSI yellow color to {59110, 47545, 25957}
+        set ANSI blue color to {19018, 42405, 61680}
+        set ANSI magenta color to {49601, 25186, 57054}
+        set ANSI cyan color to {16962, 46003, 49858}
+        set ANSI white color to {59110, 59110, 59110}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {20303, 22102, 26214}
+        set ANSI bright red color to {65535, 24929, 28270}
+        set ANSI bright green color to {42405, 57568, 30069}
+        set ANSI bright yellow color to {61680, 42148, 23901}
+        set ANSI bright blue color to {19789, 50372, 65535}
+        set ANSI bright magenta color to {57054, 29555, 65535}
+        set ANSI bright cyan color to {19532, 53713, 57568}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/scripts/base24-one-light.sh
+++ b/scripts/base24-one-light.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {59367, 59367, 59881}
+        set foreground color to {14392, 14906, 16962}
+
+        -- Set ANSI Colors
+        set ANSI black color to {59367, 59367, 59881}
+        set ANSI red color to {51914, 4626, 17219}
+        set ANSI green color to {20560, 41377, 20303}
+        set ANSI yellow color to {65278, 48059, 10794}
+        set ANSI blue color to {16448, 30840, 62194}
+        set ANSI magenta color to {42662, 9766, 42148}
+        set ANSI cyan color to {257, 33924, 48316}
+        set ANSI white color to {8224, 8738, 10023}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {51914, 51914, 52942}
+        set ANSI bright red color to {60652, 8738, 22616}
+        set ANSI bright green color to {28013, 47031, 27756}
+        set ANSI bright yellow color to {62708, 42919, 257}
+        set ANSI bright blue color to {28784, 39578, 62965}
+        set ANSI bright magenta color to {53456, 12079, 52685}
+        set ANSI bright cyan color to {257, 42919, 61423}
+        set ANSI bright white color to {2313, 2570, 2827}
+    end tell
+end tell
+EOF

--- a/scripts/base24-sparky.sh
+++ b/scripts/base24-sparky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {1799, 11051, 12593}
+        set foreground color to {62708, 62965, 61680}
+
+        -- Set ANSI Colors
+        set ANSI black color to {1799, 11051, 12593}
+        set ANSI red color to {65535, 22616, 23901}
+        set ANSI green color to {30840, 54998, 19275}
+        set ANSI yellow color to {64507, 56797, 16448}
+        set ANSI blue color to {17990, 39064, 52171}
+        set ANSI magenta color to {54741, 40606, 55255}
+        set ANSI cyan color to {11565, 52428, 54227}
+        set ANSI white color to {62965, 62965, 61937}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {0, 15420, 17990}
+        set ANSI bright red color to {65535, 29298, 30326}
+        set ANSI bright green color to {36494, 56797, 25957}
+        set ANSI bright yellow color to {63222, 60395, 24929}
+        set ANSI bright blue color to {26985, 46003, 59367}
+        set ANSI bright magenta color to {63993, 40863, 51657}
+        set ANSI bright cyan color to {0, 49601, 54741}
+        set ANSI bright white color to {65535, 65535, 65535}
+    end tell
+end tell
+EOF

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -7,3 +7,13 @@ base24:
   extension: .itermcolors
   output: itermcolors
   supported-systems: [base24]
+
+scripts-base16:
+  extension: .sh
+  output: scripts
+  supported-systems: [base16]
+
+scripts-base24:
+  extension: .sh
+  output: scripts
+  supported-systems: [base24]

--- a/templates/scripts-base16.mustache
+++ b/templates/scripts-base16.mustache
@@ -1,0 +1,31 @@
+#!/bin/sh
+{{=<% %>=}}
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {<%base00-rgb16-r%>, <%base00-rgb16-g%>, <%base00-rgb16-b%>}
+        set foreground color to {<%base05-rgb16-r%>, <%base05-rgb16-g%>, <%base05-rgb16-b%>}
+
+        -- Set ANSI Colors
+        set ANSI black color to {<%base00-rgb16-r%>, <%base00-rgb16-g%>, <%base00-rgb16-b%>}
+        set ANSI red color to {<%base08-rgb16-r%>, <%base08-rgb16-g%>, <%base08-rgb16-b%>}
+        set ANSI green color to {<%base0B-rgb16-r%>, <%base0B-rgb16-g%>, <%base0B-rgb16-b%>}
+        set ANSI yellow color to {<%base0A-rgb16-r%>, <%base0A-rgb16-g%>, <%base0A-rgb16-b%>}
+        set ANSI blue color to {<%base0D-rgb16-r%>, <%base0D-rgb16-g%>, <%base0D-rgb16-b%>}
+        set ANSI magenta color to {<%base0E-rgb16-r%>, <%base0E-rgb16-g%>, <%base0E-rgb16-b%>}
+        set ANSI cyan color to {<%base0C-rgb16-r%>, <%base0C-rgb16-g%>, <%base0C-rgb16-b%>}
+        set ANSI white color to {<%base06-rgb16-r%>, <%base06-rgb16-g%>, <%base06-rgb16-b%>}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {<%base02-rgb16-r%>, <%base02-rgb16-g%>, <%base02-rgb16-b%>}
+        set ANSI bright red color to {<%base08-rgb16-r%>, <%base08-rgb16-g%>, <%base08-rgb16-b%>}
+        set ANSI bright green color to {<%base0B-rgb16-r%>, <%base0B-rgb16-g%>, <%base0B-rgb16-b%>}
+        set ANSI bright yellow color to {<%base0A-rgb16-r%>, <%base0A-rgb16-g%>, <%base0A-rgb16-b%>}
+        set ANSI bright blue color to {<%base0D-rgb16-r%>, <%base0D-rgb16-g%>, <%base0D-rgb16-b%>}
+        set ANSI bright magenta color to {<%base0E-rgb16-r%>, <%base0E-rgb16-g%>, <%base0E-rgb16-b%>}
+        set ANSI bright cyan color to {<%base0C-rgb16-r%>, <%base0C-rgb16-g%>, <%base0C-rgb16-b%>}
+        set ANSI bright white color to {<%base07-rgb16-r%>, <%base07-rgb16-g%>, <%base07-rgb16-b%>}
+    end tell
+end tell
+EOF

--- a/templates/scripts-base24.mustache
+++ b/templates/scripts-base24.mustache
@@ -1,0 +1,31 @@
+#!/bin/sh
+{{=<% %>=}}
+
+osascript <<EOF
+tell application "iTerm2"
+    tell current session of current window
+        set background color to {<%base00-rgb16-r%>, <%base00-rgb16-g%>, <%base00-rgb16-b%>}
+        set foreground color to {<%base05-rgb16-r%>, <%base05-rgb16-g%>, <%base05-rgb16-b%>}
+
+        -- Set ANSI Colors
+        set ANSI black color to {<%base00-rgb16-r%>, <%base00-rgb16-g%>, <%base00-rgb16-b%>}
+        set ANSI red color to {<%base08-rgb16-r%>, <%base08-rgb16-g%>, <%base08-rgb16-b%>}
+        set ANSI green color to {<%base0B-rgb16-r%>, <%base0B-rgb16-g%>, <%base0B-rgb16-b%>}
+        set ANSI yellow color to {<%base0A-rgb16-r%>, <%base0A-rgb16-g%>, <%base0A-rgb16-b%>}
+        set ANSI blue color to {<%base0D-rgb16-r%>, <%base0D-rgb16-g%>, <%base0D-rgb16-b%>}
+        set ANSI magenta color to {<%base0E-rgb16-r%>, <%base0E-rgb16-g%>, <%base0E-rgb16-b%>}
+        set ANSI cyan color to {<%base0C-rgb16-r%>, <%base0C-rgb16-g%>, <%base0C-rgb16-b%>}
+        set ANSI white color to {<%base06-rgb16-r%>, <%base06-rgb16-g%>, <%base06-rgb16-b%>}
+
+        -- Set Bright ANSI Colors
+        set ANSI bright black color to {<%base02-rgb16-r%>, <%base02-rgb16-g%>, <%base02-rgb16-b%>}
+        set ANSI bright red color to {<%base12-rgb16-r%>, <%base12-rgb16-g%>, <%base12-rgb16-b%>}
+        set ANSI bright green color to {<%base14-rgb16-r%>, <%base14-rgb16-g%>, <%base14-rgb16-b%>}
+        set ANSI bright yellow color to {<%base13-rgb16-r%>, <%base13-rgb16-g%>, <%base13-rgb16-b%>}
+        set ANSI bright blue color to {<%base16-rgb16-r%>, <%base16-rgb16-g%>, <%base16-rgb16-b%>}
+        set ANSI bright magenta color to {<%base17-rgb16-r%>, <%base17-rgb16-g%>, <%base17-rgb16-b%>}
+        set ANSI bright cyan color to {<%base15-rgb16-r%>, <%base15-rgb16-g%>, <%base15-rgb16-b%>}
+        set ANSI bright white color to {<%base07-rgb16-r%>, <%base07-rgb16-g%>, <%base07-rgb16-b%>}
+    end tell
+end tell
+EOF


### PR DESCRIPTION
Note: Based on another PR: https://github.com/tinted-theming/tinted-iterm2/pull/12 (So don't merge this until that has been merged)

Add scripts to change theme using MacOS oascript. These scripts can be used with [Tinty](https://github.com/tinted-theming/tinty) to switch themes when the `tinty apply base16-<SCHEME NAME>` command is run.