### PR TITLE
Move to tinted-terminal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinted-theming/iterm2
+* @tinted-theming/iterm2-terminal

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,6 @@
 name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
   build-and-commit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Tinted iTerm2
 
+**Deprecated**: tinted-iterm2 and all the other Tinted Theming
+terminal template repositories have moved to a single [Tinted
+Terminal](https://github.com/tinted-theming/tinted-terminal) repository.
+
+---
+
 [Base16] and [Base24] themes for iTerm2. See [Tinted Theming] for more
 information.  
 


### PR DESCRIPTION
As discussed in https://github.com/tinted-theming/home/issues/44#issuecomment-2518520414, this PR adds a deprecation notice and links to [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). @tinted-theming/iterm2-terminal  should already have maintainer access for [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). Once this is merged I'll archive this repo.

- Add deprecation notice to README
- Remove cron job